### PR TITLE
feature: toHaveStyle custom matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ to maintain.
   * [`toHaveTextContent`](#tohavetextcontent)
   * [`toHaveAttribute`](#tohaveattribute)
   * [`toHaveClass`](#tohaveclass)
+  * [`toHaveStyle`](#tohavestyle)
 * [Inspiration](#inspiration)
 * [Other Solutions](#other-solutions)
 * [Guiding Principles](#guiding-principles)
@@ -162,6 +163,36 @@ expect(getByTestId(container, 'delete-button')).toHaveClass('btn-danger btn')
 expect(getByTestId(container, 'delete-button')).not.toHaveClass('btn-link')
 // ...
 ```
+
+### `toHaveStyle`
+
+This allows you to check if a certain element has some specific css properties
+with specific values applied. It matches only if the element has _all_ the
+expected properties applied, not just some of them.
+
+```javascript
+// add the custom expect matchers once
+import 'jest-dom/extend-expect'
+
+// ...
+// <button data-testid="delete-button" style="display: none; color: red">
+//   Delete item
+// </button>
+expect(getByTestId(container, 'delete-button')).toHaveStyle('display: none')
+expect(getByTestId(container, 'delete-button')).toHaveStyle(`
+  color: red;
+  display: none;
+`)
+expect(getByTestId(container, 'delete-button')).not.toHaveStyle(`
+  display: none;
+  color: blue;
+`)
+// ...
+```
+
+This also works with rules that are applied to the element via a class name for
+which some rules are defined in a stylesheet currently active in the document.
+The usual rules of css precedence apply.
 
 ## Inspiration
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -4,5 +4,6 @@ declare namespace jest {
     toHaveTextContent: (text: string) => R
     toHaveClass: (className: string) => R
     toBeInTheDOM: () => R
+    toHaveStyle: (css: string) => R
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "chalk": "^2.4.1",
     "css": "^2.2.3",
     "jest-diff": "^22.4.3",
-    "jest-matcher-utils": "^22.4.3"
+    "jest-matcher-utils": "^22.4.3",
+    "redent": "^2.0.0"
   },
   "devDependencies": {
     "kcd-scripts": "^0.37.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io/)",
   "license": "MIT",
   "dependencies": {
+    "chalk": "^2.4.1",
     "css": "^2.2.3",
+    "jest-diff": "^22.4.3",
     "jest-matcher-utils": "^22.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io/)",
   "license": "MIT",
   "dependencies": {
+    "css": "^2.2.3",
     "jest-matcher-utils": "^22.4.3"
   },
   "devDependencies": {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -154,6 +154,16 @@ test('.toHaveStyle', () => {
     expect(container.querySelector('.label')).not.toHaveStyle('color: white'),
   ).toThrowError()
 
+  // Make sure the test fails if the css syntax is not valid
+  expect(() =>
+    expect(container.querySelector('.label')).not.toHaveStyle(
+      'font-weight bold',
+    ),
+  ).toThrowError()
+  expect(() =>
+    expect(container.querySelector('.label')).toHaveStyle('color white'),
+  ).toThrowError()
+
   document.body.removeChild(style)
   document.body.removeChild(container)
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -147,7 +147,12 @@ test('.toHaveStyle', () => {
     font-weight: bold;
   `)
 
-  expect(container.querySelector('.label')).not.toHaveStyle('font-weight: bold')
+  expect(() =>
+    expect(container.querySelector('.label')).toHaveStyle('font-weight: bold'),
+  ).toThrowError()
+  expect(() =>
+    expect(container.querySelector('.label')).not.toHaveStyle('color: white'),
+  ).toThrowError()
 
   document.body.removeChild(style)
   document.body.removeChild(container)

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -109,3 +109,46 @@ test('.toHaveClass', () => {
     expect(queryByTestId('cancel-button')).toHaveClass('btn-danger'),
   ).toThrowError()
 })
+
+test('.toHaveStyle', () => {
+  const {container} = render(`
+    <div class="label" style="background-color: blue; height: 100%">
+      Hello World
+    </div>
+  `)
+
+  const style = document.createElement('style')
+  style.innerHTML = `
+    .label {
+      background-color: black;
+      color: white;
+      float: left;
+    }
+  `
+  document.body.appendChild(style)
+  document.body.appendChild(container)
+
+  expect(container.querySelector('.label')).toHaveStyle(`
+    height: 100%;
+    color: white;
+    background-color: blue;
+  `)
+
+  expect(container.querySelector('.label')).toHaveStyle(`
+    background-color: blue;
+    color: white;
+  `)
+  expect(container.querySelector('.label')).toHaveStyle(
+    'background-color:blue;color:white',
+  )
+
+  expect(container.querySelector('.label')).not.toHaveStyle(`
+    color: white;
+    font-weight: bold;
+  `)
+
+  expect(container.querySelector('.label')).not.toHaveStyle('font-weight: bold')
+
+  document.body.removeChild(style)
+  document.body.removeChild(container)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,12 @@ import {toBeInTheDOM} from './to-be-in-the-dom'
 import {toHaveTextContent} from './to-have-text-content'
 import {toHaveAttribute} from './to-have-attribute'
 import {toHaveClass} from './to-have-class'
+import {toHaveStyle} from './to-have-style'
 
-export {toBeInTheDOM, toHaveTextContent, toHaveAttribute, toHaveClass}
+export {
+  toBeInTheDOM,
+  toHaveTextContent,
+  toHaveAttribute,
+  toHaveClass,
+  toHaveStyle,
+}

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,0 +1,38 @@
+import {matcherHint} from 'jest-matcher-utils'
+import {checkHtmlElement, getMessage} from './utils'
+
+function parseCSS(css) {
+  const props = css
+    .split(/\s*;\s*/)
+    .map(str => str.split(':').map(s => s.trim()))
+    .filter(prop => prop.length === 2)
+  return props.reduce(
+    (result, [prop, value]) => Object.assign(result, {[prop]: value}),
+    {},
+  )
+}
+
+function isSubset(styles, computedStyle) {
+  return Object.entries(styles).every(([prop, value]) => {
+    return computedStyle.getPropertyValue(prop) === value
+  })
+}
+
+export function toHaveStyle(htmlElement, css) {
+  checkHtmlElement(htmlElement)
+  const expected = parseCSS(css)
+  const received = getComputedStyle(htmlElement)
+  return {
+    pass: isSubset(expected, received),
+    message: () => {
+      const to = this.isNot ? 'not to' : 'to'
+      return getMessage(
+        matcherHint(`${this.isNot ? '.not' : ''}.toHaveStyle`, 'element', ''),
+        `Expected the element ${to} have style`,
+        JSON.stringify(expected),
+        'Received',
+        JSON.stringify(received),
+      )
+    },
+  }
+}

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,15 +1,14 @@
+import {parse} from 'css'
 import {matcherHint} from 'jest-matcher-utils'
 import {checkHtmlElement, getMessage} from './utils'
 
 function parseCSS(css) {
-  const props = css
-    .split(/\s*;\s*/)
-    .map(str => str.split(':').map(s => s.trim()))
-    .filter(prop => prop.length === 2)
-  return props.reduce(
-    (result, [prop, value]) => Object.assign(result, {[prop]: value}),
-    {},
-  )
+  return parse(`selector { ${css} }`)
+    .stylesheet.rules[0].declarations.filter(d => d.type === 'declaration')
+    .reduce(
+      (obj, {property, value}) => Object.assign(obj, {[property]: value}),
+      {},
+    )
 }
 
 function isSubset(styles, computedStyle) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+import redent from 'redent'
 import {
   RECEIVED_COLOR as receivedColor,
   EXPECTED_COLOR as expectedColor,
@@ -21,10 +22,6 @@ function checkHtmlElement(htmlElement) {
   }
 }
 
-function indent(str) {
-  return `  ${str.replace(/\n/g, '\n  ')}`
-}
-
 function getMessage(
   matcher,
   expectedLabel,
@@ -34,8 +31,8 @@ function getMessage(
 ) {
   return [
     `${matcher}\n`,
-    `${expectedLabel}:\n${expectedColor(indent(expectedValue))}`,
-    `${receivedLabel}:\n${receivedColor(indent(receivedValue))}`,
+    `${expectedLabel}:\n${expectedColor(redent(expectedValue, 2))}`,
+    `${receivedLabel}:\n${receivedColor(redent(receivedValue, 2))}`,
   ].join('\n')
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,10 @@ function checkHtmlElement(htmlElement) {
   }
 }
 
+function indent(str) {
+  return `  ${str.replace(/\n/g, '\n  ')}`
+}
+
 function getMessage(
   matcher,
   expectedLabel,
@@ -30,8 +34,8 @@ function getMessage(
 ) {
   return [
     `${matcher}\n`,
-    `${expectedLabel}:\n  ${expectedColor(expectedValue)}`,
-    `${receivedLabel}:\n  ${receivedColor(receivedValue)}`,
+    `${expectedLabel}:\n${expectedColor(indent(expectedValue))}`,
+    `${receivedLabel}:\n${receivedColor(indent(receivedValue))}`,
   ].join('\n')
 }
 


### PR DESCRIPTION
**What**:

A new `.toHaveStyle` custom matcher, as proposed in #6.

Closes #6

**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Replace `parseCSS` with a more robust alternative (like [this](https://github.com/reworkcss/css))
* [ ] Support passing styles in POJO form (?)
