### PR TITLE
fix: improved error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "css": "^2.2.3",
     "jest-diff": "^22.4.3",
     "jest-matcher-utils": "^22.4.3",
+    "pretty-format": "^23.0.1",
     "redent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toBeInTheDOM 1`] = `
+"<dim>expect(</><red>element</><dim>).not.toBeInTheDOM(</><dim>)</>
+
+Received:
+  <red><span data-testid=\\"count-value\\" /></>"
+`;
+
+exports[`.toBeInTheDOM 2`] = `
+"<dim>expect(</><red>element</><dim>).toBeInTheDOM(</><dim>)</>
+
+Received:
+  <red>null</>"
+`;
+
+exports[`.toBeInTheDOM 3`] = `
+"<dim>expect(</><red>received</><dim>).toBeInTheDOM(</><dim>)</>
+
+<red>received</> value must be an HTMLElement.
+Received:
+  object: <red>{\\"thisIsNot\\": \\"an html element\\"}</>"
+`;
+
+exports[`.toBeVisible 1`] = `
+"<dim>expect(</><red>element</><dim>).not.toBeVisible(</><dim>)</>
+
+Received element is visible:
+  <red><header /></>"
+`;
+
+exports[`.toBeVisible 2`] = `
+"<dim>expect(</><red>element</><dim>).toBeVisible(</><dim>)</>
+
+Received element is not visible:
+  <red><p /></>"
+`;
+
+exports[`.toHaveAttribute 1`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveAttribute(</><green><green>\\"disabled\\"<green></><dim>) // element.hasAttribute(\\"disabled\\")</>
+
+Expected the element not to have attribute:
+<green>  disabled</>
+Received:
+<red>  disabled=\\"\\"</>"
+`;
+
+exports[`.toHaveAttribute 2`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveAttribute(</><green><green>\\"type\\"<green></><dim>) // element.hasAttribute(\\"type\\")</>
+
+Expected the element not to have attribute:
+<green>  type</>
+Received:
+<red>  type=\\"submit\\"</>"
+`;
+
+exports[`.toHaveAttribute 3`] = `
+"<dim>expect(</><red>element</><dim>).toHaveAttribute(</><green><green>\\"class\\"<green></><dim>) // element.hasAttribute(\\"class\\")</>
+
+Expected the element to have attribute:
+<green>  class</>
+Received:
+<red>  null</>"
+`;
+
+exports[`.toHaveAttribute 4`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveAttribute(</><green><green>\\"type\\"<green></><dim>, </><green><green>\\"submit\\"<green></><dim>) // element.getAttribute(\\"type\\") === \\"submit\\"</>
+
+Expected the element not to have attribute:
+<green>  type=\\"submit\\"</>
+Received:
+<red>  type=\\"submit\\"</>"
+`;
+
+exports[`.toHaveAttribute 5`] = `
+"<dim>expect(</><red>element</><dim>).toHaveAttribute(</><green><green>\\"type\\"<green></><dim>, </><green><green>\\"button\\"<green></><dim>) // element.getAttribute(\\"type\\") === \\"button\\"</>
+
+Expected the element to have attribute:
+<green>  type=\\"button\\"</>
+Received:
+<red>  type=\\"submit\\"</>"
+`;
+
+exports[`.toHaveAttribute 6`] = `
+"<dim>expect(</><red>received</><dim>).not.toHaveAttribute(</><dim>)</>
+
+<red>received</> value must be an HTMLElement.
+Received:
+  object: <red>{\\"thisIsNot\\": \\"an html element\\"}</>"
+`;
+
+exports[`.toHaveClass 1`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveClass(</><green><green>\\"btn\\"<green></><dim>)</>
+
+Expected the element not to have class:
+<green>  btn</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 2`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveClass(</><green><green>\\"btn-danger\\"<green></><dim>)</>
+
+Expected the element not to have class:
+<green>  btn-danger</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 3`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveClass(</><green><green>\\"extra\\"<green></><dim>)</>
+
+Expected the element not to have class:
+<green>  extra</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 4`] = `
+"<dim>expect(</><red>element</><dim>).toHaveClass(</><green><green>\\"xtra\\"<green></><dim>)</>
+
+Expected the element to have class:
+<green>  xtra</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 5`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveClass(</><green><green>\\"btn btn-danger\\"<green></><dim>)</>
+
+Expected the element not to have class:
+<green>  btn btn-danger</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 6`] = `
+"<dim>expect(</><red>element</><dim>).toHaveClass(</><green><green>\\"btn-link\\"<green></><dim>)</>
+
+Expected the element to have class:
+<green>  btn-link</>
+Received:
+<red>  btn extra btn-danger</>"
+`;
+
+exports[`.toHaveClass 7`] = `
+"<dim>expect(</><red>element</><dim>).toHaveClass(</><green><green>\\"btn-danger\\"<green></><dim>)</>
+
+Expected the element to have class:
+<green>  btn-danger</>
+Received:
+"
+`;
+
+exports[`.toHaveStyle 1`] = `
+"<dim>expect(</><red>element</><dim>).toHaveStyle(</><dim>)</>
+
+<green>- Expected</>
+
+<green>- font-weight: bold;</>
+<dim>  </>
+<red>+ </>"
+`;
+
+exports[`.toHaveStyle 2`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveStyle(</><dim>)</>
+
+<dim>Compared values have no visual difference.</>"
+`;
+
+exports[`.toHaveStyle 3`] = `"Syntax error parsing expected css: property missing ':' in 1:24"`;
+
+exports[`.toHaveStyle 4`] = `"Syntax error parsing expected css: property missing ':' in 1:18"`;
+
+exports[`.toHaveTextContent 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveTextContent(</><dim>)</>
+
+<red>received</> value must be an HTMLElement.
+Received: <red>null</>"
+`;
+
+exports[`.toHaveTextContent 2`] = `
+"<dim>expect(</><red>element</><dim>).toHaveTextContent(</><dim>)</>
+
+Expected element to have text content:
+<green>  3</>
+Received:
+<red>  2</>"
+`;
+
+exports[`.toHaveTextContent 3`] = `
+"<dim>expect(</><red>element</><dim>).not.toHaveTextContent(</><dim>)</>
+
+Expected element not to have text content:
+<green>  2</>
+Received:
+<red>  2</>"
+`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,5 +1,8 @@
 import '../extend-expect'
+import {plugins} from 'pretty-format'
 import {render} from './helpers/test-utils'
+
+expect.addSnapshotSerializer(plugins.ConvertAnsi)
 
 test('.toBeInTheDOM', () => {
   const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
@@ -10,13 +13,13 @@ test('.toBeInTheDOM', () => {
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
     expect(queryByTestId('count-value')).not.toBeInTheDOM(),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('count-value1')).toBeInTheDOM(),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect({thisIsNot: 'an html element'}).toBeInTheDOM(),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('.toHaveTextContent', () => {
@@ -27,14 +30,14 @@ test('.toHaveTextContent', () => {
   expect(queryByTestId('count-value')).not.toHaveTextContent('21')
   expect(() =>
     expect(queryByTestId('count-value2')).toHaveTextContent('2'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 
   expect(() =>
     expect(queryByTestId('count-value')).toHaveTextContent('3'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('.toHaveAttribute', () => {
@@ -52,19 +55,22 @@ test('.toHaveAttribute', () => {
 
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('disabled'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('type'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('ok-button')).toHaveAttribute('class'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('ok-button')).not.toHaveAttribute('type', 'submit'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('ok-button')).toHaveAttribute('type', 'button'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
+  expect(() =>
+    expect({thisIsNot: 'an html element'}).not.toHaveAttribute(),
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('.toHaveClass', () => {
@@ -89,25 +95,25 @@ test('.toHaveClass', () => {
 
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn-danger'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('extra'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('xtra'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn btn-danger'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('btn-link'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(queryByTestId('cancel-button')).toHaveClass('btn-danger'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('.toHaveStyle', () => {
@@ -149,20 +155,20 @@ test('.toHaveStyle', () => {
 
   expect(() =>
     expect(container.querySelector('.label')).toHaveStyle('font-weight: bold'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(container.querySelector('.label')).not.toHaveStyle('color: white'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 
   // Make sure the test fails if the css syntax is not valid
   expect(() =>
     expect(container.querySelector('.label')).not.toHaveStyle(
       'font-weight bold',
     ),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(container.querySelector('.label')).toHaveStyle('color white'),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 
   document.body.removeChild(style)
   document.body.removeChild(container)
@@ -194,8 +200,8 @@ test('.toBeVisible', () => {
 
   expect(() =>
     expect(container.querySelector('header')).not.toBeVisible(),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
   expect(() =>
     expect(container.querySelector('p')).toBeVisible(),
-  ).toThrowError()
+  ).toThrowErrorMatchingSnapshot()
 })

--- a/src/to-be-in-the-dom.js
+++ b/src/to-be-in-the-dom.js
@@ -1,21 +1,19 @@
-import {matcherHint} from 'jest-matcher-utils'
-import {checkHtmlElement, getMessage} from './utils'
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
 
 export function toBeInTheDOM(received) {
   if (received) {
-    checkHtmlElement(received)
+    checkHtmlElement(received, toBeInTheDOM, this)
   }
   return {
     pass: !!received,
     message: () => {
-      const to = this.isNot ? 'not to' : 'to'
-      return getMessage(
+      return [
         matcherHint(`${this.isNot ? '.not' : ''}.toBeInTheDOM`, 'element', ''),
-        'Expected',
-        `element ${to} be present`,
-        'Received',
-        received,
-      )
+        '',
+        'Received:',
+        `  ${printReceived(received ? received.cloneNode(false) : received)}`,
+      ].join('\n')
     },
   }
 }

--- a/src/to-be-visible.js
+++ b/src/to-be-visible.js
@@ -1,5 +1,5 @@
-import {matcherHint} from 'jest-matcher-utils'
-import {checkHtmlElement, getMessage} from './utils'
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
 
 function isStyleVisible(element) {
   const {display, visibility, opacity} = getComputedStyle(element)
@@ -20,20 +20,18 @@ function isElementVisible(element) {
 }
 
 export function toBeVisible(element) {
-  checkHtmlElement(element)
+  checkHtmlElement(element, toBeVisible, this)
   const isVisible = isElementVisible(element)
   return {
     pass: isVisible,
     message: () => {
-      const to = this.isNot ? 'not to' : 'to'
       const is = isVisible ? 'is' : 'is not'
-      return getMessage(
+      return [
         matcherHint(`${this.isNot ? '.not' : ''}.toBeVisible`, 'element', ''),
-        'Expected',
-        `element ${to} be visible`,
-        'Received',
-        `element ${is} visible`,
-      )
+        '',
+        `Received element ${is} visible:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
     },
   }
 }

--- a/src/to-have-attribute.js
+++ b/src/to-have-attribute.js
@@ -12,7 +12,7 @@ function getAttributeComment(name, value) {
 }
 
 export function toHaveAttribute(htmlElement, name, expectedValue) {
-  checkHtmlElement(htmlElement)
+  checkHtmlElement(htmlElement, toHaveAttribute, this)
   const isExpectedValuePresent = expectedValue !== undefined
   const hasAttribute = htmlElement.hasAttribute(name)
   const receivedValue = htmlElement.getAttribute(name)

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -13,7 +13,7 @@ function isSubset(subset, superset) {
 }
 
 export function toHaveClass(htmlElement, expectedClassNames) {
-  checkHtmlElement(htmlElement)
+  checkHtmlElement(htmlElement, toHaveClass, this)
   const received = splitClassNames(htmlElement.getAttribute('class'))
   const expected = splitClassNames(expectedClassNames)
   return {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -32,6 +32,7 @@ function printoutStyles(styles) {
     .sort()
     .map(prop => `${prop}: ${styles[prop]};`)
     .join('\n')
+    .concat('\n') // ensure multiline for diff
 }
 
 // Highlights only style rules that were expected but were not found in the
@@ -53,7 +54,7 @@ function expectedDiff(expected, computedStyles) {
 }
 
 export function toHaveStyle(htmlElement, css) {
-  checkHtmlElement(htmlElement)
+  checkHtmlElement(htmlElement, toHaveStyle, this)
   const {parsedRules: expected, parsingError} = parseCSS(css)
   if (parsingError) {
     return {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -2,7 +2,7 @@ import {matcherHint} from 'jest-matcher-utils'
 import {checkHtmlElement, getMessage, matches} from './utils'
 
 export function toHaveTextContent(htmlElement, checkWith) {
-  checkHtmlElement(htmlElement)
+  checkHtmlElement(htmlElement, toHaveTextContent, this)
   const textContent = htmlElement.textContent
   return {
     pass: matches(textContent, htmlElement, checkWith),


### PR DESCRIPTION
**What**:
 * It fixes several errors which are thrown with type related messages, e.g. toBeInTheDOM fails with
    - str.match is not a function
    - Cannot read property 'match' of null
 * Also fixes when received value is not html element: error stack was not captured and nice picture of the guilty line was not shown.
* Added snapshots to prevent similar errors in the future

**Why**:
   User experience matters for developers too.

**How**:
  Mostly by copying ideas from original jest/expect package.

**Checklist**:

* [ ] Documentation "N/A"
* [x] Tests
* [x] Ready to be merged

