### PR TITLE
TS - Adding toBeVisible declaration

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -4,6 +4,7 @@ declare namespace jest {
     toHaveTextContent: (text: string) => R
     toHaveClass: (className: string) => R
     toBeInTheDOM: () => R
+    toBeVisible: () => R
     toHaveStyle: (css: string) => R
   }
 }


### PR DESCRIPTION
**What**:

Adding toBeVisible to typescript definitions

**Why**:

To help typescript to know about the toBeVisible matcher

**How**:

I added the toBeVisible declaration as part of the interface

**Checklist**:

* [x] Documentation N\A
* [x] Tests N\A
* [x] Ready to be merged
* [x] Added myself to contributors table N/A

