### PR TITLE
fix: Types incorrectly pulling in .src

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,5 +1,3 @@
-import {toContainElement} from './src'
-
 declare namespace jest {
   interface Matchers<R> {
     toBeInTheDOM: (container?: HTMLElement) => R


### PR DESCRIPTION
**What**:
A fix for types where it was incorrectly pulling in .src

**Why**:
It will cause errors in Typescript when trying to compile a project with jest-dom

**How**:
Removed the unnecessary reference

**Checklist**:
* [x] Documentation - N/A
* [x] Tests - N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
