### PR TITLE
Accept multiple classname arguments in toHaveClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,15 @@ import 'jest-dom/extend-expect'
 // </button>
 expect(getByTestId(container, 'delete-button')).toHaveClass('extra')
 expect(getByTestId(container, 'delete-button')).toHaveClass('btn-danger btn')
+expect(getByTestId(container, 'delete-button')).toHaveClass([
+  'btn-danger',
+  'btn',
+])
 expect(getByTestId(container, 'delete-button')).not.toHaveClass('btn-link')
+expect(getByTestId(container, 'delete-button')).not.toHaveClass([
+  'btn',
+  'btn-link',
+])
 // ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -218,15 +218,8 @@ import 'jest-dom/extend-expect'
 // </button>
 expect(getByTestId(container, 'delete-button')).toHaveClass('extra')
 expect(getByTestId(container, 'delete-button')).toHaveClass('btn-danger btn')
-expect(getByTestId(container, 'delete-button')).toHaveClass([
-  'btn-danger',
-  'btn',
-])
+expect(getByTestId(container, 'delete-button')).toHaveClass('btn-danger', 'btn')
 expect(getByTestId(container, 'delete-button')).not.toHaveClass('btn-link')
-expect(getByTestId(container, 'delete-button')).not.toHaveClass([
-  'btn',
-  'btn-link',
-])
 // ...
 ```
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -5,7 +5,7 @@ declare namespace jest {
     toBeEmpty(): R
     toContainElement(element: HTMLElement): R
     toHaveAttribute(attr: string, value?: string): R
-    toHaveClass(classNames: string | string[]): R
+    toHaveClass(...classNames: string[]): R
     toHaveStyle(css: string): R
     toHaveTextContent(text: string | RegExp): R
   }

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -5,7 +5,7 @@ declare namespace jest {
     toBeEmpty(): R
     toContainElement(element: HTMLElement): R
     toHaveAttribute(attr: string, value?: string): R
-    toHaveClass(className: string): R
+    toHaveClass(classNames: string | string[]): R
     toHaveStyle(css: string): R
     toHaveTextContent(text: string | RegExp): R
   }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -224,15 +224,20 @@ test('.toHaveClass', () => {
     </div>
   `)
 
+  expect(queryByTestId('delete-button')).toHaveClass()
   expect(queryByTestId('delete-button')).toHaveClass('btn')
   expect(queryByTestId('delete-button')).toHaveClass('btn-danger')
-  expect(queryByTestId('delete-button')).toHaveClass(['btn-danger'])
   expect(queryByTestId('delete-button')).toHaveClass('extra')
   expect(queryByTestId('delete-button')).not.toHaveClass('xtra')
   expect(queryByTestId('delete-button')).not.toHaveClass('btn xtra')
-  expect(queryByTestId('delete-button')).not.toHaveClass(['btn', 'xtra'])
+  expect(queryByTestId('delete-button')).not.toHaveClass('btn', 'xtra')
+  expect(queryByTestId('delete-button')).not.toHaveClass('btn', 'extra xtra')
   expect(queryByTestId('delete-button')).toHaveClass('btn btn-danger')
-  expect(queryByTestId('delete-button')).toHaveClass(['btn', 'btn-danger'])
+  expect(queryByTestId('delete-button')).toHaveClass('btn', 'btn-danger')
+  expect(queryByTestId('delete-button')).toHaveClass(
+    'btn extra',
+    'btn-danger extra',
+  )
   expect(queryByTestId('delete-button')).not.toHaveClass('btn-link')
   expect(queryByTestId('cancel-button')).not.toHaveClass('btn-danger')
   expect(queryByTestId('svg-spinner')).toHaveClass('spinner')
@@ -240,13 +245,13 @@ test('.toHaveClass', () => {
   expect(queryByTestId('svg-spinner')).not.toHaveClass('wise')
 
   expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass(),
+  ).toThrowError()
+  expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn'),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn-danger'),
-  ).toThrowError()
-  expect(() =>
-    expect(queryByTestId('delete-button')).not.toHaveClass(['btn-danger']),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('extra'),
@@ -255,19 +260,16 @@ test('.toHaveClass', () => {
     expect(queryByTestId('delete-button')).toHaveClass('xtra'),
   ).toThrowError()
   expect(() =>
-    expect(queryByTestId('delete-button')).toHaveClass(['xtra']),
+    expect(queryByTestId('delete-button')).toHaveClass('xtra'),
   ).toThrowError()
   expect(() =>
-    expect(queryByTestId('delete-button')).toHaveClass(['btn', 'xtra']),
+    expect(queryByTestId('delete-button')).toHaveClass('btn', 'extra xtra'),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn btn-danger'),
   ).toThrowError()
   expect(() =>
-    expect(queryByTestId('delete-button')).not.toHaveClass([
-      'btn',
-      'btn-danger',
-    ]),
+    expect(queryByTestId('delete-button')).not.toHaveClass('btn', 'btn-danger'),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('btn-link'),

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -226,9 +226,13 @@ test('.toHaveClass', () => {
 
   expect(queryByTestId('delete-button')).toHaveClass('btn')
   expect(queryByTestId('delete-button')).toHaveClass('btn-danger')
+  expect(queryByTestId('delete-button')).toHaveClass(['btn-danger'])
   expect(queryByTestId('delete-button')).toHaveClass('extra')
   expect(queryByTestId('delete-button')).not.toHaveClass('xtra')
+  expect(queryByTestId('delete-button')).not.toHaveClass('btn xtra')
+  expect(queryByTestId('delete-button')).not.toHaveClass(['btn', 'xtra'])
   expect(queryByTestId('delete-button')).toHaveClass('btn btn-danger')
+  expect(queryByTestId('delete-button')).toHaveClass(['btn', 'btn-danger'])
   expect(queryByTestId('delete-button')).not.toHaveClass('btn-link')
   expect(queryByTestId('cancel-button')).not.toHaveClass('btn-danger')
   expect(queryByTestId('svg-spinner')).toHaveClass('spinner')
@@ -242,13 +246,28 @@ test('.toHaveClass', () => {
     expect(queryByTestId('delete-button')).not.toHaveClass('btn-danger'),
   ).toThrowError()
   expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass(['btn-danger']),
+  ).toThrowError()
+  expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('extra'),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('xtra'),
   ).toThrowError()
   expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(['xtra']),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(['btn', 'xtra']),
+  ).toThrowError()
+  expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn btn-danger'),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass([
+      'btn',
+      'btn-danger',
+    ]),
   ).toThrowError()
   expect(() =>
     expect(queryByTestId('delete-button')).toHaveClass('btn-link'),

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -15,7 +15,9 @@ function isSubset(subset, superset) {
 export function toHaveClass(htmlElement, expectedClassNames) {
   checkHtmlElement(htmlElement, toHaveClass, this)
   const received = splitClassNames(htmlElement.getAttribute('class'))
-  const expected = splitClassNames(expectedClassNames)
+  const expected = Array.isArray(expectedClassNames)
+    ? expectedClassNames
+    : splitClassNames(expectedClassNames)
   return {
     pass: isSubset(expected, received),
     message: () => {

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -12,12 +12,13 @@ function isSubset(subset, superset) {
   return subset.every(item => superset.includes(item))
 }
 
-export function toHaveClass(htmlElement, expectedClassNames) {
+export function toHaveClass(htmlElement, ...expectedClassNames) {
   checkHtmlElement(htmlElement, toHaveClass, this)
   const received = splitClassNames(htmlElement.getAttribute('class'))
-  const expected = Array.isArray(expectedClassNames)
-    ? expectedClassNames
-    : splitClassNames(expectedClassNames)
+  const expected = expectedClassNames.reduce(
+    (acc, className) => acc.concat(splitClassNames(className)),
+    [],
+  )
   return {
     pass: isSubset(expected, received),
     message: () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Allow multiple class name arguments to be provided to `toHaveClass`.

<!-- Why are these changes necessary? -->

**Why**:
If class names are stored in variables (i.e., if classes are generated at compile or run time), this is a more natural way to assert that multiple classes have been applied. Without this, string concatenation, templating, or multiple assertions would have to be used.

```js
// Before
expect(element).toHaveClass(`${styles.classOne} ${styles.classTwo}`);

// After
expect(element).toHaveClass(styles.classOne, styles.classTwo);
```

~I debated using a variable arguments list rather than an explicit array, but the latter seemed simpler.~

<!-- How were these changes implemented? -->

**How**:

~Checked argument type for array.~

Accept variable argument list, split each argument, and flatten results.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->

Open to suggestions on the API or happy to close the PR if this functionality is out of scope for the library.