### PR TITLE
Change toHaveClass behaviour for empty class list

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,17 @@ expect(getByTestId(container, 'delete-button')).not.toHaveClass('btn-link')
 // ...
 ```
 
+You must provide at least one class, unless you are asserting that an element
+does not have any classes.
+
+```javascript
+// ...
+// <button data-testid="no-classes">
+//   Delete item
+// </button>
+expect(getByTestId(container, 'no-classes')).not.toHaveClass()
+```
+
 ### `toHaveStyle`
 
 ```typescript

--- a/src/__tests__/to-have-class.js
+++ b/src/__tests__/to-have-class.js
@@ -14,6 +14,7 @@ test('.toHaveClass', () => {
       <svg data-testid="svg-spinner" class="spinner clockwise">
         <path />
       </svg>
+      <div data-testid="no-classes"></div>
     </div>
   `)
 
@@ -35,19 +36,9 @@ test('.toHaveClass', () => {
   expect(queryByTestId('svg-spinner')).toHaveClass('spinner')
   expect(queryByTestId('svg-spinner')).toHaveClass('clockwise')
   expect(queryByTestId('svg-spinner')).not.toHaveClass('wise')
+  expect(queryByTestId('no-classes')).not.toHaveClass()
+  expect(queryByTestId('no-classes')).not.toHaveClass(' ')
 
-  expect(() =>
-    expect(queryByTestId('delete-button')).toHaveClass(),
-  ).toThrowError(/At least one expected class must be provided/)
-  expect(() =>
-    expect(queryByTestId('delete-button')).not.toHaveClass(),
-  ).toThrowError(/At least one expected class must be provided/)
-  expect(() =>
-    expect(queryByTestId('delete-button')).toHaveClass(''),
-  ).toThrowError(/At least one expected class must be provided/)
-  expect(() =>
-    expect(queryByTestId('delete-button')).not.toHaveClass('  '),
-  ).toThrowError(/At least one expected class must be provided/)
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn'),
   ).toThrowError()
@@ -84,4 +75,19 @@ test('.toHaveClass', () => {
   expect(() =>
     expect(queryByTestId('svg-spinner')).toHaveClass('wise'),
   ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(),
+  ).toThrowError(/At least one expected class must be provided/)
+  expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(''),
+  ).toThrowError(/At least one expected class must be provided/)
+  expect(() => expect(queryByTestId('no-classes')).toHaveClass()).toThrowError(
+    /At least one expected class must be provided/,
+  )
+  expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass(),
+  ).toThrowError(/(none)/)
+  expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass('  '),
+  ).toThrowError(/(none)/)
 })

--- a/src/__tests__/to-have-class.js
+++ b/src/__tests__/to-have-class.js
@@ -1,3 +1,5 @@
+/* eslint max-statements:off */
+
 import {render} from './helpers/test-utils'
 
 test('.toHaveClass', () => {
@@ -15,7 +17,6 @@ test('.toHaveClass', () => {
     </div>
   `)
 
-  expect(queryByTestId('delete-button')).toHaveClass()
   expect(queryByTestId('delete-button')).toHaveClass('btn')
   expect(queryByTestId('delete-button')).toHaveClass('btn-danger')
   expect(queryByTestId('delete-button')).toHaveClass('extra')
@@ -36,8 +37,17 @@ test('.toHaveClass', () => {
   expect(queryByTestId('svg-spinner')).not.toHaveClass('wise')
 
   expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(),
+  ).toThrowError(/At least one expected class must be provided/)
+  expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass(),
-  ).toThrowError()
+  ).toThrowError(/At least one expected class must be provided/)
+  expect(() =>
+    expect(queryByTestId('delete-button')).toHaveClass(''),
+  ).toThrowError(/At least one expected class must be provided/)
+  expect(() =>
+    expect(queryByTestId('delete-button')).not.toHaveClass('  '),
+  ).toThrowError(/At least one expected class must be provided/)
   expect(() =>
     expect(queryByTestId('delete-button')).not.toHaveClass('btn'),
   ).toThrowError()

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -19,21 +19,30 @@ export function toHaveClass(htmlElement, ...expectedClassNames) {
     (acc, className) => acc.concat(splitClassNames(className)),
     [],
   )
-  return {
-    pass: isSubset(expected, received),
-    message: () => {
-      const to = this.isNot ? 'not to' : 'to'
-      return getMessage(
-        matcherHint(
-          `${this.isNot ? '.not' : ''}.toHaveClass`,
-          'element',
-          printExpected(expected.join(' ')),
-        ),
-        `Expected the element ${to} have class`,
-        expected.join(' '),
-        'Received',
-        received.join(' '),
-      )
-    },
-  }
+  return expected.length > 0
+    ? {
+        pass: isSubset(expected, received),
+        message: () => {
+          const to = this.isNot ? 'not to' : 'to'
+          return getMessage(
+            matcherHint(
+              `${this.isNot ? '.not' : ''}.toHaveClass`,
+              'element',
+              printExpected(expected.join(' ')),
+            ),
+            `Expected the element ${to} have class`,
+            expected.join(' '),
+            'Received',
+            received.join(' '),
+          )
+        },
+      }
+    : {
+        pass: this.isNot,
+        message: () =>
+          [
+            matcherHint(`${this.isNot ? '.not' : ''}.toHaveClass`, 'element'),
+            'At least one expected class must be provided.',
+          ].join('\n'),
+      }
 }

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -38,11 +38,19 @@ export function toHaveClass(htmlElement, ...expectedClassNames) {
         },
       }
     : {
-        pass: this.isNot,
+        pass: this.isNot ? received.length > 0 : false,
         message: () =>
-          [
-            matcherHint(`${this.isNot ? '.not' : ''}.toHaveClass`, 'element'),
-            'At least one expected class must be provided.',
-          ].join('\n'),
+          this.isNot
+            ? getMessage(
+                matcherHint('.not.toHaveClass', 'element', ''),
+                'Expected the element to have classes',
+                '(none)',
+                'Received',
+                received.join(' '),
+              )
+            : [
+                matcherHint(`.toHaveClass`, 'element'),
+                'At least one expected class must be provided.',
+              ].join('\n'),
       }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
- Require at least one expected class in `toHaveClass` (per https://github.com/gnapse/jest-dom/pull/31#issuecomment-404225469)
- `.not.toHaveClass()` asserts that the actual class list is empty (per https://github.com/gnapse/jest-dom/pull/31#issuecomment-404307031)

**Why**:
<!-- Why are these changes necessary? -->
- Invoking `toHaveClass` without expected classes will always pass, but is probably indicative of a developer mistake.
- Asserting that a class list is empty (`.not.toHaveClass()`) was not previously possible using this library

**How**:
<!-- How were these changes implemented? -->
- Conditional result based on number of expected classes
  - `expected.length > 0` &rarr; previous behaviour
  - `expected.length === 0` and `isNot` &rarr; assert `received.length === 0`
  - `expected.length === 0` and `!isNot` &rarr; fail (at least one class required)

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [ ] Updated Type Definitions N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->