### PR TITLE
feat: Depreciate toBeInTheDOM with replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ expect(queryByTestId(container, 'not-empty')).not.toBeEmpty()
 toBeInTheDocument()
 ```
 
-This allows you to assert whether an element present in the document or not.
+This allows you to assert whether an element is present in the document or not.
 
 ```javascript
 // add the custom expect matchers once

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ import 'jest-dom/extend-expect'
 // const svgElement = document.querySelector('[data-testid="html-element"]')
 // const detachedElement = document.createElement('div')
 
-expect(queryByTestId(container, 'count-value').toBeInTheDocument()
+expect(htmlElement).toBeInTheDocument()
+expect(svgElement).toBeInTheDocument()
 expect(detacthedElement).not.toBeInTheDocument()
 // ...
 ```

--- a/README.md
+++ b/README.md
@@ -131,9 +131,14 @@ This allows you to assert whether an element is present in the document or not.
 import 'jest-dom/extend-expect'
 
 // ...
-// <span data-testid="count-value">2</span>
+// document.body.innerHTML = `<span data-testid="html-element"><span>Html Element</span></span><svg data-testid="svg-element"></svg>`
+
+// const htmlElement = document.querySelector('[data-testid="html-element"]')
+// const svgElement = document.querySelector('[data-testid="html-element"]')
+// const detachedElement = document.createElement('div')
+
 expect(queryByTestId(container, 'count-value').toBeInTheDocument()
-expect(queryByTestId(container, 'count-value1')).not.toBeInTheDocument()
+expect(detacthedElement).not.toBeInTheDocument()
 // ...
 ```
 
@@ -363,9 +368,11 @@ expect(getByText(container, 'LINK')).not.toBeDisabled()
 
 ### `toBeInTheDOM`
 
-> Please use [`toBeInTheDocument`](#tobeinthedocument) for searching the entire document.
+> Note: The differences between `toBeInTheDOM` and `toBeInTheDocument` are significant. Replacing all uses of `toBeInTheDOM` with `toBeInTheDocument` will likely cause unintended consequences in your tests. Please make sure when replacing `toBeInTheDOM` to read through the replacements below to see which use case works better for your needs.
 
 > Please use [`toContainElement`](#tocontainelement) for searching a specific container.
+
+> Please use [`toBeInTheDocument`](#tobeinthedocument) for searching the entire document.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ to maintain.
 - [Installation](#installation)
 - [Usage](#usage)
 - [Custom matchers](#custom-matchers)
-  - [`toBeInTheDOM`](#tobeinthedom)
   - [`toBeEmpty`](#tobeempty)
+  - [`toBeInTheDocument`](#tobeinthedocument)
   - [`toContainElement`](#tocontainelement)
   - [`toHaveTextContent`](#tohavetextcontent)
   - [`toHaveAttribute`](#tohaveattribute)
@@ -55,6 +55,8 @@ to maintain.
   - [`toHaveFocus`](#tohavefocus)
   - [`toBeVisible`](#tobevisible)
   - [`toBeDisabled`](#tobedisabled)
+- [Deprecated matchers](#deprecated-matchers)
+  - [`toBeInTheDOM`](#tobeinthedom)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
 - [Guiding Principles](#guiding-principles)
@@ -87,57 +89,15 @@ Alternatively, you can selectively import only the matchers you intend to use,
 and extend jest's `expect` yourself:
 
 ```javascript
-import {toBeInTheDOM, toHaveClass} from 'jest-dom'
+import {toBeInTheDocument, toHaveClass} from 'jest-dom'
 
-expect.extend({toBeInTheDOM, toHaveClass})
+expect.extend({toBeInTheDocument, toHaveClass})
 ```
 
 > Note: when using TypeScript, this way of importing matchers won't provide the
 > necessary type definitions. More on this [here](https://github.com/gnapse/jest-dom/pull/11#issuecomment-387817459).
 
 ## Custom matchers
-
-### `toBeInTheDOM`
-
-```typescript
-toBeInTheDOM(container?: HTMLElement | SVGElement)
-```
-
-This allows you to assert whether an element present in the DOM container or not. If no DOM container is specified it will use the default DOM context.
-
-#### Using the default DOM container
-
-```javascript
-// add the custom expect matchers once
-import 'jest-dom/extend-expect'
-
-// ...
-// <span data-testid="count-value">2</span>
-expect(queryByTestId(container, 'count-value')).toBeInTheDOM()
-expect(queryByTestId(container, 'count-value1')).not.toBeInTheDOM()
-// ...
-```
-
-#### Using a specified DOM container
-
-```javascript
-// add the custom expect matchers once
-import 'jest-dom/extend-expect'
-
-// ...
-// <span data-testid="ancestor"><span data-testid="descendant"></span></span>
-expect(queryByTestId(container, 'descendant')).toBeInTheDOM(
-  queryByTestId(container, 'ancestor'),
-)
-expect(queryByTestId(container, 'ancestor')).not.toBeInTheDOM(
-  queryByTestId(container, 'descendant'),
-)
-// ...
-```
-
-> Note: when using `toBeInTheDOM`, make sure you use a query function
-> (like `queryByTestId`) rather than a get function (like `getByTestId`).
-> Otherwise the `get*` function could throw an error before your assertion.
 
 ### `toBeEmpty`
 
@@ -157,6 +117,27 @@ expect(queryByTestId(container, 'empty')).toBeEmpty()
 expect(queryByTestId(container, 'not-empty')).not.toBeEmpty()
 // ...
 ```
+
+### `toBeInTheDocument`
+
+```typescript
+toBeInTheDocument()
+```
+
+This allows you to assert whether an element present in the document or not.
+
+```javascript
+// add the custom expect matchers once
+import 'jest-dom/extend-expect'
+
+// ...
+// <span data-testid="count-value">2</span>
+expect(queryByTestId(container, 'count-value').toBeInTheDocument()
+expect(queryByTestId(container, 'count-value1')).not.toBeInTheDocument()
+// ...
+```
+
+> Note: This will not find detached elements. The element must be added to the document to be found. If you desire to search in a detached element please use: [`toContainElement`](#tocontainelement)
 
 ### `toContainElement`
 
@@ -377,6 +358,14 @@ expect(getByTestId(container, 'text')).toBeDisabled()
 expect(getByText(container, 'LINK')).not.toBeDisabled()
 // ...
 ```
+
+## Deprecated matchers
+
+### `toBeInTheDOM`
+
+> Please use [`toBeInTheDocument`](#tobeinthedocument) for searching the entire document.
+
+> Please use [`toContainElement`](#tocontainelement) for searching a specific container.
 
 ## Inspiration
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,6 +1,10 @@
 declare namespace jest {
   interface Matchers<R> {
+    /**
+     * @deprecated
+     */
     toBeInTheDOM(container?: HTMLElement | SVGElement): R
+    toBeInTheDocument(): R
     toBeVisible(): R
     toBeEmpty(): R
     toBeDisabled(): R

--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -1,0 +1,20 @@
+test('.toBeInTheDocument', () => {
+  document.body.innerHTML = `
+    <span data-testid="html-element"><span>Html Element</span></span>
+    <svg data-testid="svg-element"></svg>`
+
+  const htmlElement = document.querySelector('[data-testid="html-element"]')
+  const svgElement = document.querySelector('[data-testid="html-element"]')
+  const detachedElement = document.createElement('div')
+  const fakeElement = {thisIsNot: 'an html element'}
+
+  expect(htmlElement).toBeInTheDocument()
+  expect(svgElement).toBeInTheDocument()
+  expect(detachedElement).not.toBeInTheDocument()
+
+  // negative test cases wrapped in throwError assertions for coverage.
+  expect(() => expect(htmlElement).not.toBeInTheDocument()).toThrowError()
+  expect(() => expect(svgElement).not.toBeInTheDocument()).toThrowError()
+  expect(() => expect(detachedElement).toBeInTheDocument()).toThrowError()
+  expect(() => expect(fakeElement).toBeInTheDocument()).toThrowError()
+})

--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -7,6 +7,8 @@ test('.toBeInTheDocument', () => {
   const svgElement = document.querySelector('[data-testid="html-element"]')
   const detachedElement = document.createElement('div')
   const fakeElement = {thisIsNot: 'an html element'}
+  const undefinedElement = undefined
+  const nullElement = null
 
   expect(htmlElement).toBeInTheDocument()
   expect(svgElement).toBeInTheDocument()
@@ -17,4 +19,6 @@ test('.toBeInTheDocument', () => {
   expect(() => expect(svgElement).not.toBeInTheDocument()).toThrowError()
   expect(() => expect(detachedElement).toBeInTheDocument()).toThrowError()
   expect(() => expect(fakeElement).toBeInTheDocument()).toThrowError()
+  expect(() => expect(undefinedElement).toBeInTheDocument()).toThrowError()
+  expect(() => expect(nullElement).toBeInTheDocument()).toThrowError()
 })

--- a/src/__tests__/to-be-in-the-dom.js
+++ b/src/__tests__/to-be-in-the-dom.js
@@ -1,6 +1,9 @@
 import {render} from './helpers/test-utils'
 
 test('.toBeInTheDOM', () => {
+  // @deprecated intentionally hiding warnings for test clarity
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
   const {queryByTestId} = render(`
     <span data-testid="count-container">
       <span data-testid="count-value"></span>
@@ -51,4 +54,6 @@ test('.toBeInTheDOM', () => {
   expect(() => {
     expect(valueElement).toBeInTheDOM(fakeElement)
   }).toThrowError()
+
+  spy.mockRestore()
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,4 +1,6 @@
-import {deprecate} from '../utils'
+import {checkDocumentKey, deprecate} from '../utils'
+
+function matcherMock() {}
 
 test('deprecate', () => {
   const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -13,4 +15,34 @@ test('deprecate', () => {
   expect(spy).toHaveBeenCalledWith(message, undefined)
 
   spy.mockRestore()
+})
+
+test('checkDocumentKey', () => {
+  const fakeKey = 'fakeKey'
+  const realKey = 'documentElement'
+  const message = `${fakeKey} is undefined on document but is required to use ${
+    matcherMock.name
+  }.`
+
+  expect(() =>
+    checkDocumentKey(document, realKey, matcherMock),
+  ).not.toThrowError()
+
+  expect(() => {
+    checkDocumentKey(document, fakeKey, matcherMock)
+  }).toThrowError()
+
+  try {
+    checkDocumentKey(document, fakeKey, matcherMock)
+  } catch (error) {
+    expect(error.message).toBe(message)
+    expect(error.constructor.name).toBe('InvalidDocumentError')
+  }
+
+  expect(() => {
+    //eslint-disable-next-line no-undef
+    checkDocumentKey(undefined, realKey, matcherMock)
+  }).toThrow(
+    'document is undefined on global but is required to use matcherMock.',
+  )
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -20,9 +20,12 @@ test('deprecate', () => {
 test('checkDocumentKey', () => {
   const fakeKey = 'fakeKey'
   const realKey = 'documentElement'
-  const message = `${fakeKey} is undefined on document but is required to use ${
+  const badKeyMessage = `${fakeKey} is undefined on document but is required to use ${
     matcherMock.name
   }.`
+
+  const badDocumentMessage =
+    'document is undefined on global but is required to use matcherMock.'
 
   expect(() =>
     checkDocumentKey(document, realKey, matcherMock),
@@ -30,19 +33,10 @@ test('checkDocumentKey', () => {
 
   expect(() => {
     checkDocumentKey(document, fakeKey, matcherMock)
-  }).toThrowError()
-
-  try {
-    checkDocumentKey(document, fakeKey, matcherMock)
-  } catch (error) {
-    expect(error.message).toBe(message)
-    expect(error.constructor.name).toBe('InvalidDocumentError')
-  }
+  }).toThrow(badKeyMessage)
 
   expect(() => {
     //eslint-disable-next-line no-undef
     checkDocumentKey(undefined, realKey, matcherMock)
-  }).toThrow(
-    'document is undefined on global but is required to use matcherMock.',
-  )
+  }).toThrow(badDocumentMessage)
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -24,8 +24,9 @@ test('checkDocumentKey', () => {
     matcherMock.name
   }.`
 
-  const badDocumentMessage =
-    'document is undefined on global but is required to use matcherMock.'
+  const badDocumentMessage = `document is undefined on global but is required to use ${
+    matcherMock.name
+  }.`
 
   expect(() =>
     checkDocumentKey(document, realKey, matcherMock),

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,15 +1,16 @@
-import {deprecate, getDepreciationMessage} from '../utils'
+import {deprecate} from '../utils'
 
 test('deprecate', () => {
   const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const name = 'test'
+  const replacement = 'test'
+  const message = `Warning: ${name} has been deprecated and will be removed in future updates.`
 
-  const messageWithReplacement = getDepreciationMessage('test', 'test')
-  deprecate('test', 'test')
-  expect(spy).toHaveBeenCalledWith(messageWithReplacement)
+  deprecate(name, replacement)
+  expect(spy).toHaveBeenCalledWith(message, replacement)
 
-  const messageWithoutReplacement = getDepreciationMessage('test')
-  deprecate('test')
-  expect(spy).toHaveBeenCalledWith(messageWithoutReplacement)
+  deprecate(name)
+  expect(spy).toHaveBeenCalledWith(message, undefined)
 
   spy.mockRestore()
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,0 +1,15 @@
+import {deprecate, getDepreciationMessage} from '../utils'
+
+test('deprecate', () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  const messageWithReplacement = getDepreciationMessage('test', 'test')
+  deprecate('test', 'test')
+  expect(spy).toHaveBeenCalledWith(messageWithReplacement)
+
+  const messageWithoutReplacement = getDepreciationMessage('test')
+  deprecate('test')
+  expect(spy).toHaveBeenCalledWith(messageWithoutReplacement)
+
+  spy.mockRestore()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {toBeInTheDOM} from './to-be-in-the-dom'
+import {toBeInTheDocument} from './to-be-in-the-document'
 import {toBeEmpty} from './to-be-empty'
 import {toContainElement} from './to-contain-element'
 import {toHaveTextContent} from './to-have-text-content'
@@ -11,6 +12,7 @@ import {toBeDisabled} from './to-be-disabled'
 
 export {
   toBeInTheDOM,
+  toBeInTheDocument,
   toBeEmpty,
   toContainElement,
   toHaveTextContent,

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -1,0 +1,24 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
+
+export function toBeInTheDocument(element) {
+  checkHtmlElement(element, toBeInTheDocument, this)
+
+  return {
+    pass: document.documentElement.contains(element),
+    message: () => {
+      return [
+        matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeInTheDocument`,
+          'element',
+          '',
+        ),
+        '',
+        'Received:',
+        `  ${printReceived(
+          element.hasChildNodes() ? element.cloneNode(false) : element,
+        )}`,
+      ].join('\n')
+    },
+  }
+}

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -1,8 +1,9 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, checkDocumentKey} from './utils'
 
 export function toBeInTheDocument(element) {
   checkHtmlElement(element, toBeInTheDocument, this)
+  checkDocumentKey(global.document, 'documentElement', toBeInTheDocument)
 
   return {
     pass: document.documentElement.contains(element),

--- a/src/to-be-in-the-dom.js
+++ b/src/to-be-in-the-dom.js
@@ -1,7 +1,12 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, deprecate} from './utils'
 
 export function toBeInTheDOM(element, container) {
+  deprecate(
+    'toBeInTheDOM',
+    'Please use toBeInTheDocument for searching the entire document and toContainElement for searching a specific container.',
+  )
+
   if (element) {
     checkHtmlElement(element, toBeInTheDOM, this)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,6 +40,39 @@ function checkHtmlElement(htmlElement, ...args) {
   }
 }
 
+class InvalidDocumentError extends Error {
+  constructor(message, matcherFn) {
+    super()
+
+    /* istanbul ignore next */
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, matcherFn)
+    }
+
+    this.message = message
+  }
+}
+
+function checkDocumentKey(document, key, matcherFn) {
+  if (typeof document === 'undefined') {
+    throw new InvalidDocumentError(
+      `document is undefined on global but is required to use ${
+        matcherFn.name
+      }.`,
+      matcherFn,
+    )
+  }
+
+  if (typeof document[key] === 'undefined') {
+    throw new InvalidDocumentError(
+      `${key} is undefined on document but is required to use ${
+        matcherFn.name
+      }.`,
+      matcherFn,
+    )
+  }
+}
+
 function display(value) {
   return typeof value === 'string' ? value : stringify(value)
 }
@@ -75,4 +108,4 @@ function deprecate(name, replacementText) {
   )
 }
 
-export {checkHtmlElement, getMessage, matches, deprecate}
+export {checkDocumentKey, checkHtmlElement, deprecate, getMessage, matches}

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,28 +67,12 @@ function matches(textToMatch, node, matcher) {
 }
 
 function deprecate(name, replacementText) {
-  const message = getDepreciationMessage(name, replacementText)
-
   // Notify user that they are using deprecated functionality.
   // eslint-disable-next-line no-console
-  console.warn(message)
-}
-
-function getDepreciationMessage(name, replacementText) {
-  return [
-    'Warning:',
-    name,
-    'has been deprecated and will be removed in future updates.',
+  console.warn(
+    `Warning: ${name} has been deprecated and will be removed in future updates.`,
     replacementText,
-  ]
-    .join(' ')
-    .trim()
+  )
 }
 
-export {
-  checkHtmlElement,
-  getMessage,
-  matches,
-  deprecate,
-  getDepreciationMessage,
-}
+export {checkHtmlElement, getMessage, matches, deprecate}

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,4 +66,29 @@ function matches(textToMatch, node, matcher) {
   }
 }
 
-export {checkHtmlElement, getMessage, matches}
+function deprecate(name, replacementText) {
+  const message = getDepreciationMessage(name, replacementText)
+
+  // Notify user that they are using deprecated functionality.
+  // eslint-disable-next-line no-console
+  console.warn(message)
+}
+
+function getDepreciationMessage(name, replacementText) {
+  return [
+    'Warning:',
+    name,
+    'has been deprecated and will be removed in future updates.',
+    replacementText,
+  ]
+    .join(' ')
+    .trim()
+}
+
+export {
+  checkHtmlElement,
+  getMessage,
+  matches,
+  deprecate,
+  getDepreciationMessage,
+}


### PR DESCRIPTION
**What**:
Deprecating toBeInTheDOM
Adding toBeInTheDocument


**Why**:
Aiming to implement desires from conversation in issue #34


**How**:
Added a deprecate function to warn of deprecation
Added jsdoc to types to label as deprecated
Added toBeInTheDocument function
Updated documentation to have deprecated notices
Added toBeInTheDocument to documentation


**Checklist**:

* [x] Documentation
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged
* [x] Added myself to contributors table

<!-- feel free to add additional comments -->
@gnapse, @jgoz, and @kentcdodds Here is the first attempt to do the changes we discussed in #34, when you have time please review. :-) !
