### PR TITLE
feat: assert whether a string Element is in the document OR contained…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -179,6 +179,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "6ewis",
+      "name": "Lewis",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/840609?v=4",
+      "profile": "https://github.com/6ewis",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -48,6 +48,7 @@ to maintain.
   - [`toBeEmpty`](#tobeempty)
   - [`toBeInTheDocument`](#tobeinthedocument)
   - [`toContainElement`](#tocontainelement)
+  - [`toContainHtml`](#tocontainhtml)
   - [`toHaveTextContent`](#tohavetextcontent)
   - [`toHaveAttribute`](#tohaveattribute)
   - [`toHaveClass`](#tohaveclass)
@@ -166,6 +167,27 @@ expect(ancestor).toContainElement(descendant)
 expect(descendant).not.toContainElement(ancestor)
 // ...
 ```
+
+### `toContainHtml`
+
+```typescript
+toContainHtml(htmlText: String)
+```
+
+Assert whether a string representing a HTML element is contained in another Element:
+
+```javascript
+// add the custom expect matchers once
+import 'jest-dom/extend-expect'
+
+// ...
+// <span data-testid="parent"><span data-testid="child"></span></span>
+const parent = queryByTestId('parent')
+expect(parentElement).toContainHtml('<span data-testid="child"></span>')
+// ...
+```
+
+> Note: Chances are you probably do not need to use this method. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised. It might come in handy in rare cases such as if your users manipulate the DOM such as a content management tool - where users are expected to type custom HTML. please use: [`toContainElement`](#tocontainelement)
 
 ### `toHaveTextContent`
 
@@ -401,7 +423,7 @@ value is indeed an `HTMLElement` you can always use some of
 
 ```js
 expect(document.querySelector('.ok-button')).toBeInstanceOf(HTMLElement)
-expect(document.querySelector('.cancel-button')).toBeThruthy();
+expect(document.querySelector('.cancel-button')).toBeThruthy()
 ```
 
 > Note: The differences between `toBeInTheDOM` and `toBeInTheDocument` are
@@ -448,7 +470,7 @@ Thanks goes to these people ([emoji key][emojis]):
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=kentcdodds "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/gnapse/jest-dom/commits?author=kentcdodds "Tests") | [<img src="https://avatars1.githubusercontent.com/u/2430381?v=4" width="100px;"/><br /><sub><b>Ryan Castner</b></sub>](http://audiolion.github.io)<br />[📖](https://github.com/gnapse/jest-dom/commits?author=audiolion "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/8008023?v=4" width="100px;"/><br /><sub><b>Daniel Sandiego</b></sub>](https://www.dnlsandiego.com)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=dnlsandiego "Code") | [<img src="https://avatars2.githubusercontent.com/u/12592677?v=4" width="100px;"/><br /><sub><b>Paweł Mikołajczyk</b></sub>](https://github.com/Miklet)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=Miklet "Code") | [<img src="https://avatars3.githubusercontent.com/u/464978?v=4" width="100px;"/><br /><sub><b>Alejandro Ñáñez Ortiz</b></sub>](http://co.linkedin.com/in/alejandronanez/)<br />[📖](https://github.com/gnapse/jest-dom/commits?author=alejandronanez "Documentation") | [<img src="https://avatars0.githubusercontent.com/u/1402095?v=4" width="100px;"/><br /><sub><b>Matt Parrish</b></sub>](https://github.com/pbomb)<br />[🐛](https://github.com/gnapse/jest-dom/issues?q=author%3Apbomb "Bug reports") [💻](https://github.com/gnapse/jest-dom/commits?author=pbomb "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=pbomb "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=pbomb "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1288694?v=4" width="100px;"/><br /><sub><b>Justin Hall</b></sub>](https://github.com/wKovacs64)<br />[📦](#platform-wKovacs64 "Packaging/porting to new platform") |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | [<img src="https://avatars1.githubusercontent.com/u/1241511?s=460&v=4" width="100px;"/><br /><sub><b>Anto Aravinth</b></sub>](https://github.com/antoaravinth)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=antoaravinth "Code") [⚠️](https://github.com/gnapse/jest-dom/commits?author=antoaravinth "Tests") [📖](https://github.com/gnapse/jest-dom/commits?author=antoaravinth "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/3462296?v=4" width="100px;"/><br /><sub><b>Jonah Moses</b></sub>](https://github.com/JonahMoses)<br />[📖](https://github.com/gnapse/jest-dom/commits?author=JonahMoses "Documentation") | [<img src="https://avatars1.githubusercontent.com/u/4002543?v=4" width="100px;"/><br /><sub><b>Łukasz Gandecki</b></sub>](http://team.thebrain.pro)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=lgandecki "Code") [⚠️](https://github.com/gnapse/jest-dom/commits?author=lgandecki "Tests") [📖](https://github.com/gnapse/jest-dom/commits?author=lgandecki "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/498274?v=4" width="100px;"/><br /><sub><b>Ivan Babak</b></sub>](https://sompylasar.github.io)<br />[🐛](https://github.com/gnapse/jest-dom/issues?q=author%3Asompylasar "Bug reports") [🤔](#ideas-sompylasar "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/4439618?v=4" width="100px;"/><br /><sub><b>Jesse Day</b></sub>](https://github.com/jday3)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=jday3 "Code") | [<img src="https://avatars0.githubusercontent.com/u/15199?v=4" width="100px;"/><br /><sub><b>Ernesto García</b></sub>](http://gnapse.github.io)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=gnapse "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=gnapse "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=gnapse "Tests") | [<img src="https://avatars0.githubusercontent.com/u/79312?v=4" width="100px;"/><br /><sub><b>Mark Volkmann</b></sub>](http://ociweb.com/mark/)<br />[🐛](https://github.com/gnapse/jest-dom/issues?q=author%3Amvolkmann "Bug reports") [💻](https://github.com/gnapse/jest-dom/commits?author=mvolkmann "Code") |
-| [<img src="https://avatars1.githubusercontent.com/u/1659099?v=4" width="100px;"/><br /><sub><b>smacpherson64</b></sub>](https://github.com/smacpherson64)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Tests") | [<img src="https://avatars2.githubusercontent.com/u/132233?v=4" width="100px;"/><br /><sub><b>John Gozde</b></sub>](https://github.com/jgoz)<br />[🐛](https://github.com/gnapse/jest-dom/issues?q=author%3Ajgoz "Bug reports") [💻](https://github.com/gnapse/jest-dom/commits?author=jgoz "Code") | [<img src="https://avatars2.githubusercontent.com/u/7830590?v=4" width="100px;"/><br /><sub><b>Iwona</b></sub>](https://github.com/callada)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=callada "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=callada "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=callada "Tests") |
+| [<img src="https://avatars1.githubusercontent.com/u/1659099?v=4" width="100px;"/><br /><sub><b>smacpherson64</b></sub>](https://github.com/smacpherson64)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=smacpherson64 "Tests") | [<img src="https://avatars2.githubusercontent.com/u/132233?v=4" width="100px;"/><br /><sub><b>John Gozde</b></sub>](https://github.com/jgoz)<br />[🐛](https://github.com/gnapse/jest-dom/issues?q=author%3Ajgoz "Bug reports") [💻](https://github.com/gnapse/jest-dom/commits?author=jgoz "Code") | [<img src="https://avatars2.githubusercontent.com/u/7830590?v=4" width="100px;"/><br /><sub><b>Iwona</b></sub>](https://github.com/callada)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=callada "Code") [📖](https://github.com/gnapse/jest-dom/commits?author=callada "Documentation") [⚠️](https://github.com/gnapse/jest-dom/commits?author=callada "Tests") | [<img src="https://avatars0.githubusercontent.com/u/840609?v=4" width="100px;"/><br /><sub><b>Lewis</b></sub>](https://github.com/6ewis)<br />[💻](https://github.com/gnapse/jest-dom/commits?author=6ewis "Code") |
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ expect(parentElement).toContainHTML('<span data-testid="child"></span>')
 
 > Chances are you probably do not need to use this matcher. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised.
 
-It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
+> It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
 
-It should not be used to check DOM structure that you control. Please use [`toContainElement`](#tocontainelement) instead.
+> It should not be used to check DOM structure that you control. Please use [`toContainElement`](#tocontainelement) instead.
 
 ### `toHaveTextContent`
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ expect(parentElement).toContainHTML('<span data-testid="child"></span>')
 ```
 
 > Chances are you probably do not need to use this matcher. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised.
-> \
+>
 > It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
-> \
+>
 > It should not be used to check DOM structure that you control. Please use [`toContainElement`](#tocontainelement) instead.
 
 ### `toHaveTextContent`

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ expect(parentElement).toContainHTML('<span data-testid="child"></span>')
 ```
 
 > Chances are you probably do not need to use this matcher. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised.
-
+> \
 > It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
-
+> \
 > It should not be used to check DOM structure that you control. Please use [`toContainElement`](#tocontainelement) instead.
 
 ### `toHaveTextContent`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to maintain.
   - [`toBeEmpty`](#tobeempty)
   - [`toBeInTheDocument`](#tobeinthedocument)
   - [`toContainElement`](#tocontainelement)
-  - [`toContainHtml`](#tocontainhtml)
+  - [`toContainHTML`](#tocontainhtml)
   - [`toHaveTextContent`](#tohavetextcontent)
   - [`toHaveAttribute`](#tohaveattribute)
   - [`toHaveClass`](#tohaveclass)
@@ -168,13 +168,13 @@ expect(descendant).not.toContainElement(ancestor)
 // ...
 ```
 
-### `toContainHtml`
+### `toContainHTML`
 
 ```typescript
-toContainHtml(htmlText: String)
+toContainHTML(htmlText: string)
 ```
 
-Assert whether a string representing a HTML element is contained in another Element:
+Assert whether a string representing a HTML element is contained in another element:
 
 ```javascript
 // add the custom expect matchers once
@@ -183,11 +183,15 @@ import 'jest-dom/extend-expect'
 // ...
 // <span data-testid="parent"><span data-testid="child"></span></span>
 const parent = queryByTestId('parent')
-expect(parentElement).toContainHtml('<span data-testid="child"></span>')
+expect(parentElement).toContainHTML('<span data-testid="child"></span>')
 // ...
 ```
 
-> Note: Chances are you probably do not need to use this method. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised. It might come in handy in rare cases such as if your users manipulate the DOM such as a content management tool - where users are expected to type custom HTML. please use: [`toContainElement`](#tocontainelement)
+> Chances are you probably do not need to use this matcher. We encourage testing from the perspective of how the user perceives the app in a browser. That's why testing against a specific DOM structure is not advised.
+
+It could be useful in situations where the code being tested renders html that was obtained from an external source, and you want to validate that that html code was used as intended.
+
+It should not be used to check DOM structure that you control. Please use [`toContainElement`](#tocontainelement) instead.
 
 ### `toHaveTextContent`
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -9,6 +9,7 @@ declare namespace jest {
     toBeEmpty(): R
     toBeDisabled(): R
     toContainElement(element: HTMLElement | SVGElement): R
+    toContainHTML(htmlText: string): R
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R
     toHaveStyle(css: string): R

--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -1,0 +1,31 @@
+import {render} from './helpers/test-utils'
+
+/* eslint-disable max-statements */
+test('.toContainHtml', () => {
+  const {queryByTestId} = render(`
+    <span data-testid="grandparent">
+      <span data-testid="parent">
+        <span data-testid="child"></span>
+      </span>
+    </span>
+    `)
+
+  const grandparent = queryByTestId('grandparent')
+  const parent = queryByTestId('parent')
+  const child = queryByTestId('child')
+  const nonExistantElement = queryByTestId('not-exists')
+  const fakeElement = {thisIsNot: 'an html element'}
+  const stringChildElement = '<span data-testid="child"></span>'
+
+  expect(grandparent).toContainHtml(stringChildElement)
+  expect(parent).toContainHtml(stringChildElement)
+  expect(child).toContainHtml(stringChildElement)
+
+  // negative test cases wrapped in throwError assertions for coverage.
+  expect(() =>
+    expect(nonExistantElement).not.toContainHtml(stringChildElement),
+  ).toThrowError()
+  expect(() =>
+    expect(fakeElement).toContainHtml(nonExistantElement),
+  ).toThrowError()
+})

--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -7,6 +7,7 @@ test('.toContainHtml', () => {
       <span data-testid="parent">
         <span data-testid="child"></span>
       </span>
+      <svg data-testid="svg-element"></svg>
     </span>
     `)
 
@@ -16,6 +17,7 @@ test('.toContainHtml', () => {
   const nonExistantElement = queryByTestId('not-exists')
   const fakeElement = {thisIsNot: 'an html element'}
   const stringChildElement = '<span data-testid="child"></span>'
+  const svgElement = queryByTestId('svg-element')
 
   expect(grandparent).toContainHtml(stringChildElement)
   expect(parent).toContainHtml(stringChildElement)
@@ -26,6 +28,21 @@ test('.toContainHtml', () => {
     expect(nonExistantElement).not.toContainHtml(stringChildElement),
   ).toThrowError()
   expect(() =>
-    expect(fakeElement).toContainHtml(nonExistantElement),
+    expect(nonExistantElement).not.toContainHtml(nonExistantElement),
+  ).toThrowError()
+  expect(() =>
+    expect(stringChildElement).not.toContainHtml(fakeElement),
+  ).toThrowError()
+  expect(() =>
+    expect(svgElement).toContainHtml(stringChildElement),
+  ).toThrowError()
+  expect(() =>
+    expect(grandparent).not.toContainHtml(stringChildElement),
+  ).toThrowError()
+  expect(() =>
+    expect(parent).not.toContainHtml(stringChildElement),
+  ).toThrowError()
+  expect(() =>
+    expect(child).not.toContainHtml(stringChildElement),
   ).toThrowError()
 })

--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -1,7 +1,6 @@
 import {render} from './helpers/test-utils'
 
-/* eslint-disable max-statements */
-test('.toContainHtml', () => {
+test('.toContainHTML', () => {
   const {queryByTestId} = render(`
     <span data-testid="grandparent">
       <span data-testid="parent">
@@ -17,32 +16,49 @@ test('.toContainHtml', () => {
   const nonExistantElement = queryByTestId('not-exists')
   const fakeElement = {thisIsNot: 'an html element'}
   const stringChildElement = '<span data-testid="child"></span>'
+  const nonExistantString = '<span> Does not exists </span>'
   const svgElement = queryByTestId('svg-element')
 
-  expect(grandparent).toContainHtml(stringChildElement)
-  expect(parent).toContainHtml(stringChildElement)
-  expect(child).toContainHtml(stringChildElement)
+  expect(grandparent).toContainHTML(stringChildElement)
+  expect(parent).toContainHTML(stringChildElement)
+  expect(child).toContainHTML(stringChildElement)
+  expect(grandparent).not.toContainHTML(nonExistantString)
+  expect(parent).not.toContainHTML(nonExistantString)
+  expect(child).not.toContainHTML(nonExistantString)
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
-    expect(nonExistantElement).not.toContainHtml(stringChildElement),
+    expect(nonExistantElement).not.toContainHTML(stringChildElement),
   ).toThrowError()
   expect(() =>
-    expect(nonExistantElement).not.toContainHtml(nonExistantElement),
+    expect(nonExistantElement).not.toContainHTML(nonExistantElement),
   ).toThrowError()
   expect(() =>
-    expect(stringChildElement).not.toContainHtml(fakeElement),
+    expect(stringChildElement).not.toContainHTML(fakeElement),
   ).toThrowError()
   expect(() =>
-    expect(svgElement).toContainHtml(stringChildElement),
+    expect(svgElement).toContainHTML(stringChildElement),
   ).toThrowError()
   expect(() =>
-    expect(grandparent).not.toContainHtml(stringChildElement),
+    expect(grandparent).not.toContainHTML(stringChildElement),
   ).toThrowError()
   expect(() =>
-    expect(parent).not.toContainHtml(stringChildElement),
+    expect(parent).not.toContainHTML(stringChildElement),
   ).toThrowError()
   expect(() =>
-    expect(child).not.toContainHtml(stringChildElement),
+    expect(child).not.toContainHTML(stringChildElement),
+  ).toThrowError()
+  expect(() =>
+    expect(child).not.toContainHTML(stringChildElement),
+  ).toThrowError()
+  expect(() => expect(child).toContainHTML(nonExistantString)).toThrowError()
+  expect(() => expect(parent).toContainHTML(nonExistantString)).toThrowError()
+  expect(() =>
+    expect(grandparent).toContainHTML(nonExistantString),
+  ).toThrowError()
+  expect(() => expect(child).toContainHTML(nonExistantElement)).toThrowError()
+  expect(() => expect(parent).toContainHTML(nonExistantElement)).toThrowError()
+  expect(() =>
+    expect(grandparent).toContainHTML(nonExistantElement),
   ).toThrowError()
 })

--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -1,5 +1,6 @@
 import {render} from './helpers/test-utils'
 
+/* eslint-disable max-statements */
 test('.toContainHTML', () => {
   const {queryByTestId} = render(`
     <span data-testid="grandparent">
@@ -16,6 +17,7 @@ test('.toContainHTML', () => {
   const nonExistantElement = queryByTestId('not-exists')
   const fakeElement = {thisIsNot: 'an html element'}
   const stringChildElement = '<span data-testid="child"></span>'
+  const incorrectStringHtml = '<span data-testid="child"></div>'
   const nonExistantString = '<span> Does not exists </span>'
   const svgElement = queryByTestId('svg-element')
 
@@ -25,6 +27,11 @@ test('.toContainHTML', () => {
   expect(grandparent).not.toContainHTML(nonExistantString)
   expect(parent).not.toContainHTML(nonExistantString)
   expect(child).not.toContainHTML(nonExistantString)
+  expect(child).not.toContainHTML(nonExistantString)
+  expect(grandparent).not.toContainHTML(incorrectStringHtml)
+  expect(parent).not.toContainHTML(incorrectStringHtml)
+  expect(child).not.toContainHTML(incorrectStringHtml)
+  expect(child).not.toContainHTML(incorrectStringHtml)
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
@@ -61,4 +68,12 @@ test('.toContainHTML', () => {
   expect(() =>
     expect(grandparent).toContainHTML(nonExistantElement),
   ).toThrowError()
+  expect(() =>
+    expect(nonExistantElement).toContainHTML(incorrectStringHtml),
+  ).toThrowError()
+  expect(() =>
+    expect(grandparent).toContainHTML(incorrectStringHtml),
+  ).toThrowError()
+  expect(() => expect(child).toContainHTML(incorrectStringHtml)).toThrowError()
+  expect(() => expect(parent).toContainHTML(incorrectStringHtml)).toThrowError()
 })

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import {toBeInTheDOM} from './to-be-in-the-dom'
 import {toBeInTheDocument} from './to-be-in-the-document'
 import {toBeEmpty} from './to-be-empty'
 import {toContainElement} from './to-contain-element'
-import {toContainHtml} from './to-contain-html'
+import {toContainHTML} from './to-contain-html'
 import {toHaveTextContent} from './to-have-text-content'
 import {toHaveAttribute} from './to-have-attribute'
 import {toHaveClass} from './to-have-class'
@@ -16,7 +16,7 @@ export {
   toBeInTheDocument,
   toBeEmpty,
   toContainElement,
-  toContainHtml,
+  toContainHTML,
   toHaveTextContent,
   toHaveAttribute,
   toHaveClass,

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import {toBeInTheDOM} from './to-be-in-the-dom'
 import {toBeInTheDocument} from './to-be-in-the-document'
 import {toBeEmpty} from './to-be-empty'
 import {toContainElement} from './to-contain-element'
+import {toContainHtml} from './to-contain-html'
 import {toHaveTextContent} from './to-have-text-content'
 import {toHaveAttribute} from './to-have-attribute'
 import {toHaveClass} from './to-have-class'
@@ -15,6 +16,7 @@ export {
   toBeInTheDocument,
   toBeEmpty,
   toContainElement,
+  toContainHtml,
   toHaveTextContent,
   toHaveAttribute,
   toHaveClass,

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -1,0 +1,24 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
+
+export function toContainHtml(container, htmlText) {
+  const stringToHtml = item =>
+    new DOMParser().parseFromString(item, 'text/html').body.firstChild
+  const htmlElement =
+    typeof htmlText === 'string' ? stringToHtml(htmlText) : null
+
+  checkHtmlElement(container, toContainHtml, this)
+  checkHtmlElement(htmlElement, toContainHtml, this)
+
+  return {
+    pass: container.outerHTML.includes(htmlText),
+    message: () => {
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toContainHtml`, 'element', ''),
+        '',
+        'Received:',
+        `  ${printReceived(container.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -1,20 +1,23 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
-export function toContainHtml(container, htmlText) {
-  const stringToHtml = item =>
-    new DOMParser().parseFromString(item, 'text/html').body.firstChild
+function checkHtmlText(htmlText, ...args) {
   const htmlElement =
-    typeof htmlText === 'string' ? stringToHtml(htmlText) : null
+    typeof htmlText === 'string'
+      ? new DOMParser().parseFromString(htmlText, 'text/html').body.firstChild
+      : null
+  checkHtmlElement(htmlElement, ...args)
+}
 
-  checkHtmlElement(container, toContainHtml, this)
-  checkHtmlElement(htmlElement, toContainHtml, this)
+export function toContainHTML(container, htmlText) {
+  checkHtmlElement(container, toContainHTML, this)
+  checkHtmlText(htmlText, toContainHTML, this)
 
   return {
     pass: container.outerHTML.includes(htmlText),
     message: () => {
       return [
-        matcherHint(`${this.isNot ? '.not' : ''}.toContainHtml`, 'element', ''),
+        matcherHint(`${this.isNot ? '.not' : ''}.toContainHTML`, 'element', ''),
         '',
         'Received:',
         `  ${printReceived(container.cloneNode(false))}`,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
 Assert whether a string representing a  HTML Element is in the document: `expect("<div>Example</div>").toBeInTheDocument()`

Assert whether a string representing a HTML element is contained in another Element: `expect(container).toContainElement(<div> Example </div>)`

**Why**:
<!-- Why are these changes necessary? -->
It's more intuitive to expect the methods `toContainElement()` and `toBeInTheDocument()` to expect HTML wrapped in strings.  Also, there are use cases where it makes more sense. Picture a component that receives a dynamic HTML content as an input and parse it via a HTML parser  - we could then test that the newly added DOM Element are in the document. It is more declarative - we are not only limited to query the DOM to check if an element is in the DOM. 


**How**:
<!-- How were these changes implemented? -->
Simply By checking the type of the argument, if it is a string then we verify that it is a valid HTML element first then we check that it is included in the html DOM.

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
