### PR TITLE
fix: Updated README to have correct selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ import 'jest-dom/extend-expect'
 // document.body.innerHTML = `<span data-testid="html-element"><span>Html Element</span></span><svg data-testid="svg-element"></svg>`
 
 // const htmlElement = document.querySelector('[data-testid="html-element"]')
-// const svgElement = document.querySelector('[data-testid="html-element"]')
+// const svgElement = document.querySelector('[data-testid="svg-element"]')
 // const detachedElement = document.createElement('div')
 
 expect(htmlElement).toBeInTheDocument()


### PR DESCRIPTION
**What**:
Fixed a minor error in the README


**Why**:
The error is confusing in the README


**How**:
Changed the svg selector from `html-element` and replaced with `svg-element`


**Checklist**:

* [x] Documentation
* [x] Tests N/A
* [x] Updated Type Definitions N/A
* [x] Ready to be merged
* [x] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
