### PR TITLE
fix: Updated toBeInTheDocument

### DIFF
--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -4,7 +4,7 @@ test('.toBeInTheDocument', () => {
     <svg data-testid="svg-element"></svg>`
 
   const htmlElement = document.querySelector('[data-testid="html-element"]')
-  const svgElement = document.querySelector('[data-testid="html-element"]')
+  const svgElement = document.querySelector('[data-testid="svg-element"]')
   const detachedElement = document.createElement('div')
   const fakeElement = {thisIsNot: 'an html element'}
   const undefinedElement = undefined


### PR DESCRIPTION
**What**:
The toBeInTheDocument was using the wrong selector like the README. Resetting it to check on the actual svg element.


**Why**:
This part of the test is not is not actually checking what it was intended to check.


**How**:
Updated the selector to use `svg-element` instead of `html-element`


**Checklist**:
* [x] Documentation N/A
* [x] Tests
* [x] Updated Type Definitions N/A
* [x] Ready to be merged
* [x] Added myself to contributors table N/A
