### PR TITLE
fix: Set toBeInTheDocument and toContainElement to be nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ expect(detacthedElement).not.toBeInTheDocument()
 ### `toContainElement`
 
 ```typescript
-toContainElement(element: HTMLElement | SVGElement)
+toContainElement(element?: HTMLElement | SVGElement | null)
 ```
 
 This allows you to assert whether an element contains another element as a descendant or not.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ expect(htmlElement).toBeInTheDocument()
 expect(svgElement).toBeInTheDocument()
 expect(detacthedElement).not.toBeInTheDocument()
 expect(nonExistantElement).not.toBeInTheDocument()
-// ...```
+// ...
+```
 
 > Note: This will not find detached elements. The element must be added to the document to be found. If you desire to search in a detached element please use: [`toContainElement`](#tocontainelement)
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ expect(nonExistantElement).not.toBeInTheDocument()
 ### `toContainElement`
 
 ```typescript
-toContainElement(element?: HTMLElement | SVGElement | null)
+toContainElement(element: HTMLElement | SVGElement | null)
 ```
 
 This allows you to assert whether an element contains another element as a descendant or not.

--- a/README.md
+++ b/README.md
@@ -136,13 +136,14 @@ import 'jest-dom/extend-expect'
 
 // const htmlElement = document.querySelector('[data-testid="html-element"]')
 // const svgElement = document.querySelector('[data-testid="svg-element"]')
+// const nonExistantElement = document.querySelector('does-not-exist')
 // const detachedElement = document.createElement('div')
 
 expect(htmlElement).toBeInTheDocument()
 expect(svgElement).toBeInTheDocument()
 expect(detacthedElement).not.toBeInTheDocument()
-// ...
-```
+expect(nonExistantElement).not.toBeInTheDocument()
+// ...```
 
 > Note: This will not find detached elements. The element must be added to the document to be found. If you desire to search in a detached element please use: [`toContainElement`](#tocontainelement)
 
@@ -162,9 +163,11 @@ import 'jest-dom/extend-expect'
 // <span data-testid="ancestor"><span data-testid="descendant"></span></span>
 const ancestor = queryByTestId(container, 'ancestor')
 const descendant = queryByTestId(container, 'descendant')
+const nonExistantElement = queryByTestId(container, 'does-not-exist')
 
 expect(ancestor).toContainElement(descendant)
 expect(descendant).not.toContainElement(ancestor)
+expect(ancestor).not.toContainElement(nonExistantElement)
 // ...
 ```
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -8,7 +8,7 @@ declare namespace jest {
     toBeVisible(): R
     toBeEmpty(): R
     toBeDisabled(): R
-    toContainElement(element?: HTMLElement | SVGElement | null): R
+    toContainElement(element: HTMLElement | SVGElement | null): R
     toContainHTML(htmlText: string): R
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -8,7 +8,7 @@ declare namespace jest {
     toBeVisible(): R
     toBeEmpty(): R
     toBeDisabled(): R
-    toContainElement(element: HTMLElement | SVGElement): R
+    toContainElement(element?: HTMLElement | SVGElement | null): R
     toContainHTML(htmlText: string): R
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R

--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -13,6 +13,8 @@ test('.toBeInTheDocument', () => {
   expect(htmlElement).toBeInTheDocument()
   expect(svgElement).toBeInTheDocument()
   expect(detachedElement).not.toBeInTheDocument()
+  expect(nullElement).not.toBeInTheDocument()
+  expect(undefinedElement).not.toBeInTheDocument()
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() => expect(htmlElement).not.toBeInTheDocument()).toThrowError()

--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -14,7 +14,6 @@ test('.toBeInTheDocument', () => {
   expect(svgElement).toBeInTheDocument()
   expect(detachedElement).not.toBeInTheDocument()
   expect(nullElement).not.toBeInTheDocument()
-  expect(undefinedElement).not.toBeInTheDocument()
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() => expect(htmlElement).not.toBeInTheDocument()).toThrowError()

--- a/src/__tests__/to-contain-element.js
+++ b/src/__tests__/to-contain-element.js
@@ -1,22 +1,22 @@
 import {render} from './helpers/test-utils'
 
-test('.toContainElement', () => {
-  const {queryByTestId} = render(`
-    <span data-testid="grandparent">
-      <span data-testid="parent">
-        <span data-testid="child"></span>
-      </span>
-      <svg data-testid="svg-element"></svg>
-    </span>
-    `)
+const {queryByTestId} = render(`
+<span data-testid="grandparent">
+  <span data-testid="parent">
+    <span data-testid="child"></span>
+  </span>
+  <svg data-testid="svg-element"></svg>
+</span>
+`)
 
-  const grandparent = queryByTestId('grandparent')
-  const parent = queryByTestId('parent')
-  const child = queryByTestId('child')
-  const svgElement = queryByTestId('svg-element')
-  const nonExistantElement = queryByTestId('not-exists')
-  const fakeElement = {thisIsNot: 'an html element'}
+const grandparent = queryByTestId('grandparent')
+const parent = queryByTestId('parent')
+const child = queryByTestId('child')
+const svgElement = queryByTestId('svg-element')
+const nonExistantElement = queryByTestId('not-exists')
+const fakeElement = {thisIsNot: 'an html element'}
 
+test('.toContainElement positive test cases', () => {
   expect(grandparent).toContainElement(parent)
   expect(grandparent).toContainElement(child)
   expect(grandparent).toContainElement(svgElement)
@@ -26,8 +26,11 @@ test('.toContainElement', () => {
   expect(child).not.toContainElement(parent)
   expect(child).not.toContainElement(grandparent)
   expect(child).not.toContainElement(svgElement)
+  expect(grandparent).not.toContainElement(nonExistantElement)
+  expect(grandparent).not.toContainElement(undefined)
+})
 
-  // negative test cases wrapped in throwError assertions for coverage.
+test('.toContainElement negative test cases', () => {
   expect(() =>
     expect(nonExistantElement).not.toContainElement(child),
   ).toThrowError()

--- a/src/__tests__/to-contain-element.js
+++ b/src/__tests__/to-contain-element.js
@@ -27,7 +27,6 @@ test('.toContainElement positive test cases', () => {
   expect(child).not.toContainElement(grandparent)
   expect(child).not.toContainElement(svgElement)
   expect(grandparent).not.toContainElement(nonExistantElement)
-  expect(grandparent).not.toContainElement(undefined)
 })
 
 test('.toContainElement negative test cases', () => {
@@ -58,6 +57,10 @@ test('.toContainElement negative test cases', () => {
   expect(() => expect(fakeElement).toContainElement(fakeElement)).toThrowError()
   expect(() => expect(grandparent).not.toContainElement(child)).toThrowError()
   expect(() =>
-    expect(grandparent).not.toContainElement(svgElement),
+    expect(grandparent).not.toContainElement(svgElement)
   ).toThrowError()
+  expect(() =>
+      expect(grandparent).not.toContainElement(undefined)
+  ).toThrowError()
+)
 })

--- a/src/__tests__/to-contain-element.js
+++ b/src/__tests__/to-contain-element.js
@@ -62,5 +62,4 @@ test('.toContainElement negative test cases', () => {
   expect(() =>
       expect(grandparent).not.toContainElement(undefined)
   ).toThrowError()
-)
 })

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -6,7 +6,7 @@ import {
 import {checkHtmlElement, checkDocumentKey} from './utils'
 
 export function toBeInTheDocument(element) {
-  if (element) {
+  if (element !== null && element !== undefined) {
     checkHtmlElement(element, toBeInTheDocument, this)
   }
 

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -1,8 +1,15 @@
-import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {
+  matcherHint,
+  stringify,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils'
 import {checkHtmlElement, checkDocumentKey} from './utils'
 
 export function toBeInTheDocument(element) {
-  checkHtmlElement(element, toBeInTheDocument, this)
+  if (element) {
+    checkHtmlElement(element, toBeInTheDocument, this)
+  }
+
   checkDocumentKey(global.document, 'documentElement', toBeInTheDocument)
 
   return {
@@ -15,10 +22,12 @@ export function toBeInTheDocument(element) {
           '',
         ),
         '',
-        'Received:',
-        `  ${printReceived(
-          element.hasChildNodes() ? element.cloneNode(false) : element,
-        )}`,
+        receivedColor(`${stringify(
+          document.documentElement.cloneNode(false),
+        )} ${this.isNot ? 'contains:' : 'does not contain:'} ${stringify(
+          element ? element.cloneNode(false) : element,
+        )}
+        `),
       ].join('\n')
     },
   }

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -6,7 +6,7 @@ import {
 import {checkHtmlElement, checkDocumentKey} from './utils'
 
 export function toBeInTheDocument(element) {
-  if (element !== null && element !== undefined) {
+  if (element !== null) {
     checkHtmlElement(element, toBeInTheDocument, this)
   }
 

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -9,7 +9,7 @@ export function toContainElement(container, element) {
   checkHtmlElement(container, toContainElement, this)
 
   if (element !== null && element !== undefined) {
-    checkHtmlElement(element, toBeInTheDocument, this)
+    checkHtmlElement(element, toContainElement, this)
   }
 
   return {

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -8,7 +8,7 @@ import {checkHtmlElement} from './utils'
 export function toContainElement(container, element) {
   checkHtmlElement(container, toContainElement, this)
 
-  if (element !== null && element !== undefined) {
+  if (element !== null) {
     checkHtmlElement(element, toContainElement, this)
   }
 

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -8,8 +8,8 @@ import {checkHtmlElement} from './utils'
 export function toContainElement(container, element) {
   checkHtmlElement(container, toContainElement, this)
 
-  if (element) {
-    checkHtmlElement(element, toContainElement, this)
+  if (element !== null && element !== undefined) {
+    checkHtmlElement(element, toBeInTheDocument, this)
   }
 
   return {

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -1,9 +1,16 @@
-import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {
+  matcherHint,
+  stringify,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
 export function toContainElement(container, element) {
   checkHtmlElement(container, toContainElement, this)
-  checkHtmlElement(element, toContainElement, this)
+
+  if (element) {
+    checkHtmlElement(element, toContainElement, this)
+  }
 
   return {
     pass: container.contains(element),
@@ -12,11 +19,13 @@ export function toContainElement(container, element) {
         matcherHint(
           `${this.isNot ? '.not' : ''}.toContainElement`,
           'element',
-          '',
+          'element',
         ),
         '',
-        'Received:',
-        `  ${printReceived(container.cloneNode(false))}`,
+        receivedColor(`${stringify(container.cloneNode(false))} ${
+          this.isNot ? 'contains:' : 'does not contain:'
+        } ${stringify(element ? element.cloneNode(false) : element)}
+        `),
       ].join('\n')
     },
   }


### PR DESCRIPTION
**What**:
- Set toBeInTheDocument and toContainElement to allow null and undefined.
- Adjusted response to make the failing text clearer

**Why**:
On issue #46, expressed the desire to be able to use null in toBeInTheDocument and toContainElement. This is useful when querying for elements that could result in null. It allows code like the following:

```js
// queryByText('Loading...') = null;
expect(queryByText('Loading...')).not.toBeInTheDocument()
expect(container).not.toContainElement(queryByText('Loading...'))
```

Instead of:

```js
expect(queryByText('Loading...').toBeNull();
```


**How**:
- Updated the elements in the matchers to be conditional
- Updated the matching text to make it clearer
- Updated the types to allow null and undefined


**Checklist**:
* [x] Documentation
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged
* [x] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
