### PR TITLE
feat: #9: Normalized whitespace using dom-testing-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ The usual rules of css precedence apply.
 ### `toHaveTextContent`
 
 ```typescript
-toHaveTextContent(text: string | RegExp, options?: {normalizeSpaces: boolean})
+toHaveTextContent(text: string | RegExp, options?: {normalizeWhitespace: boolean})
 ```
 
 This API allows you to check whether the given element has a text content or not.

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ The usual rules of css precedence apply.
 ### `toHaveTextContent`
 
 ```typescript
-toHaveTextContent(text: string | RegExp)
+toHaveTextContent(text: string | RegExp, options?: {normalizeSpaces: boolean})
 ```
 
 This API allows you to check whether the given element has a text content or not.

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -13,7 +13,10 @@ declare namespace jest {
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R
     toHaveStyle(css: string): R
-    toHaveTextContent(text: string | RegExp): R
+    toHaveTextContent(
+      text: string | RegExp,
+      options?: {normalizeSpaces: boolean},
+    ): R
     toHaveFocus(): R
   }
 }

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -15,7 +15,7 @@ declare namespace jest {
     toHaveStyle(css: string): R
     toHaveTextContent(
       text: string | RegExp,
-      options?: {normalizeSpaces: boolean},
+      options?: {normalizeWhitespace: boolean},
     ): R
     toHaveFocus(): R
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "css": "^2.2.3",
+    "dom-testing-library": "^3.5.0",
     "jest-diff": "^22.4.3",
     "jest-matcher-utils": "^22.4.3",
     "pretty-format": "^23.0.1",

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -26,11 +26,14 @@ describe('.toHaveTextContent', () => {
   })
 
   test('normalizes whitespace', () => {
-    const {container} = render(`<span>
-   Step
-     1
-   of 4
- </span>`)
+    const {container} = render(`
+      <span>
+        Step
+          1
+            of
+              4
+      </span>
+    `)
 
     expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4')
   })

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -25,7 +25,7 @@ describe('.toHaveTextContent', () => {
     ).toThrowError()
   })
 
-  test('normalizes whitespace', () => {
+  test('normalizes whitespace by default', () => {
     const {container} = render(`
       <span>
         Step
@@ -35,8 +35,14 @@ describe('.toHaveTextContent', () => {
       </span>
     `)
 
-    expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4', {
-      normalizeSpaces: true,
+    expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4')
+  })
+
+  test('allows whitespace normalization to be turned off', () => {
+    const {container} = render(`<span>&nbsp;&nbsp;Step 1 of 4</span>`)
+
+    expect(container.querySelector('span')).toHaveTextContent('  Step 1 of 4', {
+      normalizeWhitespace: false,
     })
   })
 })

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -1,20 +1,37 @@
 import {render} from './helpers/test-utils'
 
-test('.toHaveTextContent', () => {
-  const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+describe('.toHaveTextContent', () => {
+  test('handles positive test cases', () => {
+    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
 
-  expect(queryByTestId('count-value')).toHaveTextContent('2')
-  expect(queryByTestId('count-value')).toHaveTextContent(2)
-  expect(queryByTestId('count-value')).toHaveTextContent(/2/)
-  expect(queryByTestId('count-value')).not.toHaveTextContent('21')
-  expect(() =>
-    expect(queryByTestId('count-value2')).toHaveTextContent('2'),
-  ).toThrowError()
+    expect(queryByTestId('count-value')).toHaveTextContent('2')
+    expect(queryByTestId('count-value')).toHaveTextContent(2)
+    expect(queryByTestId('count-value')).toHaveTextContent(/2/)
+    expect(queryByTestId('count-value')).not.toHaveTextContent('21')
+  })
 
-  expect(() =>
-    expect(queryByTestId('count-value')).toHaveTextContent('3'),
-  ).toThrowError()
-  expect(() =>
-    expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
-  ).toThrowError()
+  test('handles negative test cases', () => {
+    const {queryByTestId} = render(`<span data-testid="count-value">2</span>`)
+
+    expect(() =>
+      expect(queryByTestId('count-value2')).toHaveTextContent('2'),
+    ).toThrowError()
+
+    expect(() =>
+      expect(queryByTestId('count-value')).toHaveTextContent('3'),
+    ).toThrowError()
+    expect(() =>
+      expect(queryByTestId('count-value')).not.toHaveTextContent('2'),
+    ).toThrowError()
+  })
+
+  test('normalizes whitespace', () => {
+    const {container} = render(`<span>
+   Step
+     1
+   of 4
+ </span>`)
+
+    expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4')
+  })
 })

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -35,6 +35,8 @@ describe('.toHaveTextContent', () => {
       </span>
     `)
 
-    expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4')
+    expect(container.querySelector('span')).toHaveTextContent('Step 1 of 4', {
+      normalizeSpaces: true,
+    })
   })
 })

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -2,9 +2,16 @@ import {matcherHint} from 'jest-matcher-utils'
 import {getNodeText} from 'dom-testing-library'
 import {checkHtmlElement, getMessage, matches} from './utils'
 
-export function toHaveTextContent(htmlElement, checkWith) {
+export function toHaveTextContent(
+  htmlElement,
+  checkWith,
+  options = {normalizeSpaces: false},
+) {
   checkHtmlElement(htmlElement, toHaveTextContent, this)
-  const textContent = getNodeText(htmlElement).replace(/\s+/g, ' ')
+
+  const textContent = options.normalizeSpaces
+    ? getNodeText(htmlElement).replace(/\s+/g, ' ')
+    : getNodeText(htmlElement)
 
   return {
     pass: matches(textContent, htmlElement, checkWith),

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,9 +1,11 @@
 import {matcherHint} from 'jest-matcher-utils'
+import {getNodeText} from 'dom-testing-library'
 import {checkHtmlElement, getMessage, matches} from './utils'
 
 export function toHaveTextContent(htmlElement, checkWith) {
   checkHtmlElement(htmlElement, toHaveTextContent, this)
-  const textContent = htmlElement.textContent
+  const textContent = getNodeText(htmlElement).replace(/\s+/g, ' ')
+
   return {
     pass: matches(textContent, htmlElement, checkWith),
     message: () => {

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -5,16 +5,18 @@ import {checkHtmlElement, getMessage, matches} from './utils'
 export function toHaveTextContent(
   htmlElement,
   checkWith,
-  options = {normalizeSpaces: false},
+  options = {normalizeWhitespace: true},
 ) {
   checkHtmlElement(htmlElement, toHaveTextContent, this)
 
-  const textContent = options.normalizeSpaces
-    ? getNodeText(htmlElement).replace(/\s+/g, ' ')
-    : getNodeText(htmlElement)
+  const textContent = options.normalizeWhitespace
+    ? getNodeText(htmlElement)
+        .replace(/\s+/g, ' ')
+        .trim()
+    : getNodeText(htmlElement).replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
 
   return {
-    pass: matches(textContent, htmlElement, checkWith),
+    pass: matches(textContent, checkWith),
     message: () => {
       const to = this.isNot ? 'not to' : 'to'
       return getMessage(

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ function getMessage(
   ].join('\n')
 }
 
-function matches(textToMatch, node, matcher) {
+function matches(textToMatch, matcher) {
   if (matcher instanceof RegExp) {
     return matcher.test(textToMatch)
   } else {


### PR DESCRIPTION
**What**:
Implementing #9, it required an adjustment from dom-testing-library as https://github.com/kentcdodds/dom-testing-library/pull/31 makes fuzzy logic optional.


**Why**:
To allow users to test against text with spacing that varies. The text should be normalized to only have one space.


**How**:
As discussed in #9 used [dom-testing-library](https://github.com/kentcdodds/dom-testing-library)'s [get-node-text](https://github.com/kentcdodds/dom-testing-library/blob/master/src/get-node-text.js) function and also included the regex multiple space to one space replacement.


**Checklist**:
* [x] Documentation N/A
* [x] Tests
* [x] Updated Type Definitions N/A
* [x] Ready to be merged
* [x] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
