### PR TITLE
fix: #9 adjusted to-have-text-content for multi-level text

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "css": "^2.2.3",
-    "dom-testing-library": "^3.5.0",
     "jest-diff": "^22.4.3",
     "jest-matcher-utils": "^22.4.3",
     "pretty-format": "^23.0.1",

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -45,4 +45,32 @@ describe('.toHaveTextContent', () => {
       normalizeWhitespace: false,
     })
   })
+
+  test('can handle multiple levels', () => {
+    const {container} = render(`<span id="parent"><span>Step 1 
+    
+    of 4</span></span>`)
+
+    expect(container.querySelector('#parent')).toHaveTextContent('Step 1 of 4')
+  })
+
+  test('can handle multiple levels with content spread across decendants', () => {
+    const {container} = render(`
+        <span id="parent">
+            <span>Step</span>
+            <span>      1</span>
+            <span><span>of</span></span>
+
+
+            4</span>
+        </span>
+    `)
+
+    expect(container.querySelector('#parent')).toHaveTextContent('Step 1 of 4')
+  })
+
+  test('does not throw error with empty content', () => {
+    const {container} = render(`<span></span>`)
+    expect(container.querySelector('span')).toHaveTextContent('')
+  })
 })

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,6 +1,5 @@
 import {matcherHint} from 'jest-matcher-utils'
-import {getNodeText} from 'dom-testing-library'
-import {checkHtmlElement, getMessage, matches} from './utils'
+import {checkHtmlElement, getMessage, matches, normalize} from './utils'
 
 export function toHaveTextContent(
   htmlElement,
@@ -10,10 +9,8 @@ export function toHaveTextContent(
   checkHtmlElement(htmlElement, toHaveTextContent, this)
 
   const textContent = options.normalizeWhitespace
-    ? getNodeText(htmlElement)
-        .replace(/\s+/g, ' ')
-        .trim()
-    : getNodeText(htmlElement).replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
+    ? normalize(htmlElement.textContent)
+    : htmlElement.textContent.replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
 
   return {
     pass: matches(textContent, checkWith),

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,6 +142,10 @@ function deprecate(name, replacementText) {
   )
 }
 
+function normalize(text) {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
 export {
   checkDocumentKey,
   checkHtmlElement,
@@ -149,4 +153,5 @@ export {
   deprecate,
   getMessage,
   matches,
+  normalize,
 }


### PR DESCRIPTION
**What**:
Discussions in #9 showed that `to-have-text-content` lost the ability to go multiple descendant levels. 

**Why**:
Helps fix the issue and allows `to-have-text-content` to handle what it did previously.


**How**:
Removed `dom-testing-library` dependency and replaced with `.textContent` and `normalize utility`.


**Checklist**:
* [x] Documentation N/A
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged
* [x] Added myself to contributors table N/A
