### PR TITLE
Initial toHaveFormValues implementation (closes #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ to maintain.
   - [`toHaveAttribute`](#tohaveattribute)
   - [`toHaveClass`](#tohaveclass)
   - [`toHaveFocus`](#tohavefocus)
+  - [`toHaveFormValues`](#tohaveformvalues)
   - [`toHaveStyle`](#tohavestyle)
   - [`toHaveTextContent`](#tohavetextcontent)
 - [Deprecated matchers](#deprecated-matchers)
@@ -475,6 +476,85 @@ expect(input).not.toHaveFocus()
 ```
 
 <hr />
+
+### `toHaveFormValues`
+
+```typescript
+toHaveFormValues(object)
+```
+
+This allows you to check if a form or fieldset contains form controls for each
+given name, and having the specified value.
+
+> It is important to stress that this matcher can only be invoked on a [form][]
+> or a [fieldset][] element.
+>
+> This allows it to take advantage of these elements' `[elements][]` property,
+> to reliably fetch all form controls within them.
+>
+> This also avoids the possibility that users provide a container that contains
+> more than one `form`, thereby intermixing form controls that are not related,
+> and could even conflict with one another.
+
+This matcher abstracts away the particularities with which a form control value
+is obtained depending on the type of form control. For instance, `<input>`
+elements have a `value` attribute, but `<select>` elements do not. Here's a list
+of all cases covered:
+
+- `<input type="number">` elements return the value as a **number**, instead of
+  a string.
+- `<input type="checkbox">` elements:
+  - if there's a single one with the given `name` attribute, it is treated as a
+    **boolean**, returning `true` if the checkbox is checked, `false` if
+    unchecked.
+  - if there's more than one checkbox with the same `name` attribute, they are
+    all treated collectively as a single form control, which returns the value
+    as an **array** containing all the values of the selected checkboxes in the
+    collection.
+- `<input type="radio">` elements are all grouped by the `name` attribute, and
+  such a group treated as a single form control. This form control returns the
+  value as a **string** corresponding to the `value` attribute of the selected
+  radio button within the group.
+- `<input type="text">` elements return the value as a **string**. This also
+  applies to `<input>` elements having any other possible `type` attribute
+  that's not explicitly covered in different rules above (e.g. `search`,
+  `email`, `date`, `password`, `hidden`, etc.)
+- `<select>` elements without the `multiple` attribute return the value as a
+  string corresponding to the `value` attribute of the selected `option`, or
+  `undefined` if there's no selected option.
+- `<select multiple>` elements return the value as an **array** containing all
+  the values of the [selected options][].
+- `<textarea>` elements return their value as a **string**. The value
+  corresponds to their node content.
+
+The above rules make it easy, for instance, to switch from using a single select
+control to using a group of radio buttons. Or to switch from a multi select
+control, to using a group of checkboxes. The resulting set of form values used
+by this matcher to compare against would be the same.
+
+[selected options]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedOptions
+[form]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
+[fieldset]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFieldSetElement
+[elements]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements
+
+#### Examples
+
+```html
+<form data-testid="login-form">
+  <input type="text" name="username" value="jane.doe" />
+  <input type="password" name="password" value="12345678" />
+  <input type="checkbox" name="rememberMe" checked />
+  <button type="submit">Sign in</button>
+</form>
+```
+
+```javascript
+const form = document.querySelector('[data-testid="login-form"]')
+expect(form).toHaveFormValues({
+  username: 'jane.doe',
+  rememberMe: true,
+})
+```
 
 ### `toHaveStyle`
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,9 @@ expect(input).not.toHaveFocus()
 ### `toHaveFormValues`
 
 ```typescript
-toHaveFormValues(object)
+toHaveFormValues(expectedValues: {
+  [name: string]: any
+})
 ```
 
 This allows you to check if a form or fieldset contains form controls for each
@@ -520,7 +522,7 @@ of all cases covered:
   that's not explicitly covered in different rules above (e.g. `search`,
   `email`, `date`, `password`, `hidden`, etc.)
 - `<select>` elements without the `multiple` attribute return the value as a
-  string corresponding to the `value` attribute of the selected `option`, or
+  **string** corresponding to the `value` attribute of the selected `option`, or
   `undefined` if there's no selected option.
 - `<select multiple>` elements return the value as an **array** containing all
   the values of the [selected options][].

--- a/README.md
+++ b/README.md
@@ -489,8 +489,8 @@ given name, and having the specified value.
 > It is important to stress that this matcher can only be invoked on a [form][]
 > or a [fieldset][] element.
 >
-> This allows it to take advantage of these elements' `[elements][]` property,
-> to reliably fetch all form controls within them.
+> This allows it to take advantage of the [.elements][] property in `form` and
+> `fieldset` to reliably fetch all form controls within them.
 >
 > This also avoids the possibility that users provide a container that contains
 > more than one `form`, thereby intermixing form controls that are not related,
@@ -535,7 +535,7 @@ by this matcher to compare against would be the same.
 [selected options]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/selectedOptions
 [form]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 [fieldset]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFieldSetElement
-[elements]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements
+[.elements]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements
 
 #### Examples
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -13,7 +13,7 @@ declare namespace jest {
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R
     toHaveFocus(): R
-    toHaveFormValues(object)
+    toHaveFormValues(expectedValues: {[name: string]: any}): R
     toHaveStyle(css: string): R
     toHaveTextContent(
       text: string | RegExp,

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -12,11 +12,12 @@ declare namespace jest {
     toContainHTML(htmlText: string): R
     toHaveAttribute(attr: string, value?: string): R
     toHaveClass(...classNames: string[]): R
+    toHaveFocus(): R
+    toHaveFormValues(object)
     toHaveStyle(css: string): R
     toHaveTextContent(
       text: string | RegExp,
       options?: {normalizeWhitespace: boolean},
     ): R
-    toHaveFocus(): R
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "css": "^2.2.3",
     "jest-diff": "^23.6.0",
     "jest-matcher-utils": "^23.6.0",
+    "lodash": "^4.17.11",
     "pretty-format": "^23.6.0",
     "redent": "^2.0.0"
   },

--- a/src/__tests__/to-have-form-values.js
+++ b/src/__tests__/to-have-form-values.js
@@ -185,6 +185,23 @@ describe('.toHaveFormValues', () => {
         category: undefined,
       })
     })
+
+    it('supports being called only on form and fieldset elements', () => {
+      const expectedValues = {title: 'one', description: 'two'}
+      const {container} = render(`
+        <form>
+          <input type="text" name="title" value="one">
+          <input type="text" name="description" value="two">
+        </form>
+      `)
+      const form = container.querySelector('form')
+      expect(() => {
+        expect(container).toHaveFormValues(expectedValues)
+      }).toThrowError(/a form or a fieldset/)
+      expect(() => {
+        expect(form).toHaveFormValues(expectedValues)
+      }).not.toThrowError()
+    })
   })
 
   describe('failed assertions', () => {

--- a/src/__tests__/to-have-form-values.js
+++ b/src/__tests__/to-have-form-values.js
@@ -156,8 +156,9 @@ describe('.toHaveFormValues', () => {
           <input type="radio" name="accept">
         </form>
       `)
+      const form = container.querySelector('form')
       expect(() => {
-        expect(container).toHaveFormValues({})
+        expect(form).toHaveFormValues({})
       }).toThrowError(/must be of the same type/)
     })
 
@@ -168,7 +169,8 @@ describe('.toHaveFormValues', () => {
           <input type="text" name="title" value="two">
         </form>
       `)
-      expect(container).toHaveFormValues({
+      const form = container.querySelector('form')
+      expect(form).toHaveFormValues({
         title: ['one', 'two'],
       })
     })

--- a/src/__tests__/to-have-form-values.js
+++ b/src/__tests__/to-have-form-values.js
@@ -1,0 +1,287 @@
+import {render} from './helpers/test-utils'
+
+const categories = [
+  {value: '', label: '–'},
+  {value: 'design', label: 'Design'},
+  {value: 'ux', label: 'User Experience'},
+  {value: 'programming', label: 'Programming'},
+]
+
+const skills = [
+  {value: 'c-sharp', label: 'C#'},
+  {value: 'graphql', label: 'GraphQl'},
+  {value: 'javascript', label: 'JavaScript'},
+  {value: 'ruby-on-rails', label: 'Ruby on Rails'},
+  {value: 'python', label: 'Python'},
+]
+
+const defaultValues = {
+  title: 'Full-stack developer',
+  salary: 12345,
+  category: 'programming',
+  skills: ['javascript', 'ruby-on-rails'],
+  description: 'You need to know your stuff',
+  remote: true,
+  freelancing: false,
+}
+
+function renderForm({
+  selectSingle = renderSelectSingle,
+  selectMultiple = renderSelectMultiple,
+  values: valueOverrides = {},
+} = {}) {
+  const values = {
+    ...defaultValues,
+    ...valueOverrides,
+  }
+  const {container} = render(`
+    <form>
+      <label for="title">Job title</label>
+      <input
+        type="text"
+        id="title"
+        name="title"
+        value="${values.title || ''}"
+      />
+
+      <label for="salary">Salary</label>
+      <input
+        type="number"
+        id="salary"
+        name="salary"
+        value="${values.salary}"
+      />
+
+      <label for="description">Description</label>
+      <textarea id="description" name="description">${
+        values.description
+      }</textarea>
+
+      <input
+        type="checkbox"
+        id="remote"
+        name="remote" ${values.remote ? 'checked' : ''}
+      />
+      <label for="remote">Can work remotely?</label>
+
+      <input
+        type="checkbox"
+        id="freelancing"
+        name="freelancing" ${values.freelancing ? 'checked' : ''}
+      />
+      <label for="freelancing">Freelancing?</label>
+
+      ${selectSingle('category', 'Category', categories, values.category)}
+      ${selectMultiple('skills', 'Skills', skills, values.skills)}
+    </form>
+  `)
+  return container.querySelector('form')
+}
+
+describe('.toHaveFormValues', () => {
+  it('works as expected', () => {
+    expect(renderForm()).toHaveFormValues(defaultValues)
+  })
+
+  it('allows to match partially', () => {
+    expect(renderForm()).toHaveFormValues({
+      category: 'programming',
+      salary: 12345,
+    })
+  })
+
+  it('supports checkboxes for multiple selection', () => {
+    expect(renderForm({selectMultiple: renderCheckboxes})).toHaveFormValues({
+      skills: ['javascript', 'ruby-on-rails'],
+    })
+  })
+
+  it('supports radio-buttons for single selection', () => {
+    expect(renderForm({selectSingle: renderRadioButtons})).toHaveFormValues({
+      category: 'programming',
+    })
+  })
+
+  it('matches sets of selected values regardless of the order', () => {
+    const form = renderForm()
+    expect(form).toHaveFormValues({
+      skills: ['ruby-on-rails', 'javascript'],
+    })
+    expect(form).toHaveFormValues({
+      skills: ['javascript', 'ruby-on-rails'],
+    })
+  })
+
+  it('correctly handles empty values', () => {
+    expect(
+      renderForm({
+        values: {
+          title: '',
+          salary: null,
+          category: null,
+          skills: [],
+          description: '',
+        },
+      }),
+    ).toHaveFormValues({
+      title: '',
+      salary: null,
+      category: '',
+      skills: [],
+      description: '',
+    })
+  })
+
+  it('handles <input type="number"> values correctly', () => {
+    expect(renderForm({values: {salary: 123.456}})).toHaveFormValues({
+      salary: 123.456,
+    })
+    expect(renderForm({values: {salary: '1e5'}})).toHaveFormValues({
+      salary: 1e5,
+    })
+    expect(renderForm({values: {salary: '1.35e5'}})).toHaveFormValues({
+      salary: 135000,
+    })
+    expect(renderForm({values: {salary: '-5.9'}})).toHaveFormValues({
+      salary: -5.9,
+    })
+  })
+
+  describe('edge cases', () => {
+    // This is also to ensure 100% code coverage for edge cases
+    it('detects multiple elements with the same name but different type', () => {
+      const {container} = render(`
+        <form>
+          <input type="checkbox" name="accept">
+          <input type="radio" name="accept">
+        </form>
+      `)
+      expect(() => {
+        expect(container).toHaveFormValues({})
+      }).toThrowError(/must be of the same type/)
+    })
+
+    it('detects multiple elements with the same type and name', () => {
+      const {container} = render(`
+        <form>
+          <input type="text" name="title" value="one">
+          <input type="text" name="title" value="two">
+        </form>
+      `)
+      expect(container).toHaveFormValues({
+        title: ['one', 'two'],
+      })
+    })
+
+    it('supports radio buttons with none selected', () => {
+      expect(
+        renderForm({
+          selectSingle: renderRadioButtons,
+          values: {category: undefined},
+        }),
+      ).toHaveFormValues({
+        category: undefined,
+      })
+    })
+  })
+
+  describe('failed assertions', () => {
+    it('work as expected', () => {
+      expect(() => {
+        expect(renderForm()).not.toHaveFormValues(defaultValues)
+      }).toThrowError(/Expected the element not to have form values/)
+      expect(() => {
+        expect(renderForm()).toHaveFormValues({something: 'missing'})
+      }).toThrowError(/Expected the element to have form values/)
+    })
+  })
+})
+
+// Form control renderers
+
+function isSelected(value, option) {
+  return Array.isArray(value) && value.indexOf(option.value) >= 0
+}
+
+function renderCheckboxes(name, label, options, value = []) {
+  return `
+    <fieldset>
+      <legend>${label}</legend>
+      ${renderList(
+        options,
+        option => `
+          <div>
+            <input
+              type="checkbox"
+              name="${name}[]"
+              id="${option.value}"
+              value="${option.value}"
+              ${isSelected(value, option) ? 'checked' : ''}
+            />
+            <label for="${option.value}">${option.label}</label>
+          </div>
+        `,
+      )}
+    </fieldset>
+  `
+}
+
+function renderRadioButtons(name, label, options, value = undefined) {
+  return `
+    <fieldset>
+      <legend>${label}</legend>
+      ${renderList(
+        options,
+        option => `
+          <div>
+            <input
+              type="radio"
+              name="${name}"
+              id="${option.value}"
+              value="${option.value}"
+              ${value === option.value ? 'checked' : ''}
+            />
+            <label for="${option.value}">${option.label}</label>
+          </div>
+        `,
+      )}
+    </fieldset>
+  `
+}
+
+function renderSelect(name, label, options, value, multiple) {
+  return `
+    <label for="${name}">${label}</label>
+    <select id="${name}" name="${name}" ${multiple ? 'multiple' : ''}>
+      ${renderList(
+        options,
+        option => `
+          <option
+            value="${option.value}"
+            ${isSelected(value, option) ? 'selected' : ''}
+          >
+            ${option.label}
+          </option>
+        `,
+      )}
+    </select>
+  `
+}
+
+function renderSelectSingle(name, label, options, value = undefined) {
+  return renderSelect(
+    name,
+    label,
+    options,
+    value === undefined || value === null ? [] : [value],
+    false,
+  )
+}
+
+function renderSelectMultiple(name, label, options, value = []) {
+  return renderSelect(name, label, options, value, true)
+}
+
+function renderList(items, mapper) {
+  return items.map(mapper).join('')
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {toHaveAttribute} from './to-have-attribute'
 import {toHaveClass} from './to-have-class'
 import {toHaveStyle} from './to-have-style'
 import {toHaveFocus} from './to-have-focus'
+import {toHaveFormValues} from './to-have-form-values'
 import {toBeVisible} from './to-be-visible'
 import {toBeDisabled} from './to-be-disabled'
 
@@ -22,6 +23,7 @@ export {
   toHaveClass,
   toHaveStyle,
   toHaveFocus,
+  toHaveFormValues,
   toBeVisible,
   toBeDisabled,
 }

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -93,9 +93,7 @@ function getPureName(name) {
 }
 
 function getAllFormValues(container) {
-  const names = uniq(
-    [...container.querySelectorAll('[name]')].map(element => element.name),
-  )
+  const names = Array.from(container.elements).map(element => element.name)
   return names.reduce(
     (obj, name) => ({
       ...obj,

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -105,6 +105,10 @@ function getAllFormValues(container) {
 
 export function toHaveFormValues(formElement, expectedValues) {
   checkHtmlElement(formElement, toHaveFormValues, this)
+  if (!formElement.elements) {
+    // TODO: Change condition to use instanceof against the appropriate element classes instead
+    throw new Error('toHaveFormValues must be called on a form or a fieldset')
+  }
   const formValues = getAllFormValues(formElement)
   return {
     pass: Object.entries(expectedValues).every(([name, expectedValue]) =>

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -1,0 +1,130 @@
+import {matcherHint} from 'jest-matcher-utils'
+import jestDiff from 'jest-diff'
+import {checkHtmlElement} from './utils'
+
+function uniq(value, index, self) {
+  return self.indexOf(value) === index
+}
+
+function isEqual(a, b) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    a = [...a].sort()
+    b = [...b].sort()
+  }
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function getSelectValue({multiple, selectedOptions}) {
+  if (multiple) {
+    return [...selectedOptions].map(opt => opt.value)
+  }
+  /* istanbul ignore if */
+  if (selectedOptions.length === 0) {
+    return undefined // Couldn't make this happen, but just in case
+  }
+  return selectedOptions[0].value
+}
+
+function getInputValue(inputElement) {
+  switch (inputElement.type) {
+    case 'number':
+      return inputElement.value === '' ? null : Number(inputElement.value)
+    case 'checkbox':
+      return inputElement.checked
+    default:
+      return inputElement.value
+  }
+}
+
+function getSingleElementValue(element) {
+  /* istanbul ignore if */
+  if (!element) {
+    return undefined
+  }
+  switch (element.tagName.toLowerCase()) {
+    case 'input':
+      return getInputValue(element)
+    case 'select':
+      return getSelectValue(element)
+    default:
+      return element.value
+  }
+}
+
+// Returns the combined value of several elements that have the same name
+// e.g. radio buttons or groups of checkboxes
+function getMultiElementValue(elements) {
+  const types = elements.map(element => element.type).filter(uniq)
+  if (types.length !== 1) {
+    throw new Error(
+      'Multiple form elements with the same name must be of the same type',
+    )
+  }
+  switch (types[0]) {
+    case 'radio': {
+      const theChosenOne = elements.find(radio => radio.checked)
+      return theChosenOne ? theChosenOne.value : undefined
+    }
+    case 'checkbox':
+      return elements
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.value)
+    default:
+      // NOTE: Not even sure this is a valid use case, but just in case...
+      return elements.map(element => element.value)
+  }
+}
+
+function getFormValue(container, name) {
+  const elements = [...container.querySelectorAll(`[name="${name}"]`)]
+  /* istanbul ignore if */
+  if (elements.length === 0) {
+    return undefined // shouldn't happen, but just in case
+  }
+  switch (elements.length) {
+    case 1:
+      return getSingleElementValue(elements[0])
+    default:
+      return getMultiElementValue(elements)
+  }
+}
+
+// Strips the `[]` suffix off a form value name
+function getPureName(name) {
+  return /\[\]$/.test(name) ? name.slice(0, -2) : name
+}
+
+function getAllFormValues(container) {
+  const names = [...container.querySelectorAll('[name]')]
+    .map(element => element.name)
+    .filter(uniq)
+  return names.reduce(
+    (obj, name) => ({
+      ...obj,
+      [getPureName(name)]: getFormValue(container, name),
+    }),
+    {},
+  )
+}
+
+export function toHaveFormValues(formElement, expectedValues) {
+  checkHtmlElement(formElement, toHaveFormValues, this)
+  const formValues = getAllFormValues(formElement)
+  return {
+    pass: Object.entries(expectedValues).every(([name, value]) =>
+      isEqual(formValues[name], value),
+    ),
+    message: () => {
+      const to = this.isNot ? 'not to' : 'to'
+      const matcher = `${this.isNot ? '.not' : ''}.toHaveFormValues`
+      const commonKeyValues = Object.keys(formValues)
+        .filter(key => expectedValues.hasOwnProperty(key))
+        .reduce((obj, key) => ({...obj, [key]: formValues[key]}), {})
+      return [
+        matcherHint(matcher, 'element', ''),
+        `Expected the element ${to} have form values`,
+        jestDiff(expectedValues, commonKeyValues),
+      ].join('\n\n')
+    },
+  }
+}


### PR DESCRIPTION
**What**:

Allow tests to assert that a form (or part of it) contains certain elements with certain corresponding values.

**Why**:

See #60 

**How**:

By gathering all form values under the given container, and matching it against the expected values.

Additional efforts were made to ensure a consistent gathering of form values to match more what a user interprets out of them.

- Handles single vs multiple selection `<select>`
- A set of radio buttons with the same name behave as a single select
- A set of checkboxes with the same name behave as a multi select
- `<input type="number">` is matched as a numeric value, even though internally is a string
- Several elements with the same name are grouped as an array value

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
