### PR TITLE
fix: add expected to matcher toHaveFocus

### DIFF
--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -1,4 +1,4 @@
-import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {matcherHint, printReceived, printExpected} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
 export function toHaveFocus(element) {
@@ -10,6 +10,8 @@ export function toHaveFocus(element) {
       return [
         matcherHint(`${this.isNot ? '.not' : ''}.toHaveFocus`, 'element', ''),
         '',
+        'Expected',
+        `  ${printExpected(element)}`,
         'Received:',
         `  ${printReceived(element.ownerDocument.activeElement)}`,
       ].join('\n')


### PR DESCRIPTION
**What**:
Added expected to the toHaveFocus matcher


**Why**:
It makes the test results clearer as to what is expected against what is received.


**How**:
Added the expected using `printExpected` with the element


**Checklist**:
* [x] Documentation N/A
* [x] Tests N/A
* [x] Updated Type Definitions N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table N/A

<!-- feel free to add additional comments -->
