### PR TITLE
fix: minor typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ const detachedElement = document.createElement('div')
 
 expect(htmlElement).toBeInTheDocument()
 expect(svgElement).toBeInTheDocument()
-expect(detachedElement).not.toBeInTheDocument()
 expect(nonExistantElement).not.toBeInTheDocument()
+expect(detachedElement).not.toBeInTheDocument()
 ```
 
 ##### Using dom-testing-library

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ const detachedElement = document.createElement('div')
 
 expect(htmlElement).toBeInTheDocument()
 expect(svgElement).toBeInTheDocument()
-expect(detacthedElement).not.toBeInTheDocument()
+expect(detachedElement).not.toBeInTheDocument()
 expect(nonExistantElement).not.toBeInTheDocument()
 ```
 

--- a/README.md
+++ b/README.md
@@ -587,8 +587,8 @@ expect(button).toHaveStyle(`
   display: none;
 `)
 expect(button).not.toHaveStyle(`
-  display: none;
   color: blue;
+  display: none;
 `)
 ```
 
@@ -603,8 +603,8 @@ expect(button).toHaveStyle(`
   display: none;
 `)
 expect(button).not.toHaveStyle(`
-  display: none;
   color: blue;
+  display: none;
 `)
 ```
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ expected properties applied, not just some of them.
 ##### Using document.querySelector
 
 ```javascript
-const input = document.querySelector(['data-testid="delete-button"')
+const button = document.querySelector(['data-testid="delete-button"')
 
 expect(button).toHaveStyle('display: none')
 expect(button).toHaveStyle(`
@@ -631,7 +631,7 @@ This API allows you to check whether the given element has a text content or not
 ##### Using document.querySelector
 
 ```javascript
-const button = document.querySelector('[data-testid="count-value"]')
+const content = document.querySelector('[data-testid="count-value"]')
 
 expect(content).toHaveTextContent('2')
 expect(content).toHaveTextContent(/^2$/)

--- a/README.md
+++ b/README.md
@@ -631,21 +631,21 @@ This API allows you to check whether the given element has a text content or not
 ##### Using document.querySelector
 
 ```javascript
-const content = document.querySelector('[data-testid="count-value"]')
+const element = document.querySelector('[data-testid="count-value"]')
 
-expect(content).toHaveTextContent('2')
-expect(content).toHaveTextContent(/^2$/)
-expect(content).not.toHaveTextContent('21')
+expect(element).toHaveTextContent('2')
+expect(element).toHaveTextContent(/^2$/)
+expect(element).not.toHaveTextContent('21')
 ```
 
 ##### Using dom-testing-library
 
 ```javascript
-const content = getByTestId(container, 'count-value')
+const element = getByTestId(container, 'count-value')
 
-expect(content).toHaveTextContent('2')
-expect(content).toHaveTextContent(/^2$/)
-expect(content).not.toHaveTextContent('21')
+expect(element).toHaveTextContent('2')
+expect(element).toHaveTextContent(/^2$/)
+expect(element).not.toHaveTextContent('21')
 ```
 
 <hr />


### PR DESCRIPTION
**What**:
Minor adjustments to the README:
- A typo in a variable name
- A few copy-paste errors in variable names
- Changing the order of a couple of CSS properties to make it clear that the assertion fails because of a different value, not a different order of properties

**Why**:
Just makes the docs easier to read.

**How**:
N/A

**Checklist**:
* [x] Documentation
* [ ] Tests N/A
* [ ] Updated Type Definitions N/A
* [x] Ready to be merged
* [ ] Added myself to contributors table N/A